### PR TITLE
fs-explorer: add odd and even line coloring

### DIFF
--- a/data/FSexplorer.css
+++ b/data/FSexplorer.css
@@ -7,11 +7,20 @@
 */
 body {
 	font-family: sans-serif;
-	//background-color: #a9a9a9;
+	/* background-color: #a9a9a9; */
 	background-color: lightblue;
 	display: flex;
 	flex-flow: column;
 	align-items: left;
+}
+tr:nth-child(even) {
+	background: #9dd0e1;
+}
+tr:nth-child(odd) {
+	background: #c4e3ed;
+}
+td:nth-child(n+5) {
+	background: lightblue;
 }
 h1,h2 {
 	color: #e1e1e1;

--- a/data/FSexplorer.html
+++ b/data/FSexplorer.html
@@ -34,6 +34,7 @@
                    dir += `<td width=20% nowrap>${json[i].name}</td>`;
                    dir += `<td width=10% nowrap></td>`;
                    dir += `<td width=10% nowrap></td>`;
+                   dir += `<td width=10% nowrap></td>`;
                  } 
                  else
                  {


### PR DESCRIPTION
With an increased number of files shown in fs-explorer it can be difficult to see which "download" or  "delete"  link to press for which file. line coloring makes it easier to see which link belongs to which file