### PR TITLE
Format float remove

### DIFF
--- a/helperStuff.ino
+++ b/helperStuff.ino
@@ -84,12 +84,6 @@ uint8_t splitString(String inStrng, char delimiter, String wOut[], uint8_t maxWo
 
 
 //===========================================================================================
-float formatFloat(float v, int dec)
-{
-  return (String(v, dec).toFloat());
-
-} //  formatFloat()
-//===========================================================================================
 boolean isValidIP(IPAddress ip)
 {
  /* Works as follows:

--- a/restAPI.ino
+++ b/restAPI.ino
@@ -327,18 +327,18 @@ void sendDeviceInfo()
   sendNestedJsonObj("coreversion", CSTR(ESP.getCoreVersion()) );
   sendNestedJsonObj("sdkversion",  ESP.getSdkVersion());
   sendNestedJsonObj("cpufreq", ESP.getCpuFreqMHz());
-  sendNestedJsonObj("sketchsize", formatFloat( (ESP.getSketchSize() / 1024.0), 3));
-  sendNestedJsonObj("freesketchspace", formatFloat( (ESP.getFreeSketchSpace() / 1024.0), 3));
+  sendNestedJsonObj("sketchsize",  ESP.getSketchSize());
+  sendNestedJsonObj("freesketchspace",  ESP.getFreeSketchSpace() );
 
   snprintf(cMsg, sizeof(cMsg), "%08X", ESP.getFlashChipId());
   sendNestedJsonObj("flashchipid", cMsg);  // flashChipId
-  sendNestedJsonObj("flashchipsize", formatFloat((ESP.getFlashChipSize() / 1024.0 / 1024.0), 3));
-  sendNestedJsonObj("flashchiprealsize", formatFloat((ESP.getFlashChipRealSize() / 1024.0 / 1024.0), 3));
+  sendNestedJsonObj("flashchipsize", (ESP.getFlashChipSize() / 1024.0f / 1024.0f));
+  sendNestedJsonObj("flashchiprealsize", (ESP.getFlashChipRealSize() / 1024.0f / 1024.0f));
 
   LittleFS.info(LittleFSinfo);
-  sendNestedJsonObj("LittleFSsize", formatFloat( (LittleFSinfo.totalBytes / (1024.0 * 1024.0)), 0));
+  sendNestedJsonObj("LittleFSsize", floorf( (LittleFSinfo.totalBytes / (1024.0f * 1024.0f))));
 
-  sendNestedJsonObj("flashchipspeed", formatFloat((ESP.getFlashChipSpeed() / 1000.0 / 1000.0), 0));
+  sendNestedJsonObj("flashchipspeed", floorf((ESP.getFlashChipSpeed() / 1000.0f / 1000.0f)));
 
   FlashMode_t ideMode = ESP.getFlashChipMode();
   sendNestedJsonObj("flashchipmode", flashMode[ideMode]);

--- a/restAPI.ino
+++ b/restAPI.ino
@@ -328,7 +328,7 @@ void sendDeviceInfo()
   sendNestedJsonObj("sdkversion",  ESP.getSdkVersion());
   sendNestedJsonObj("cpufreq", ESP.getCpuFreqMHz());
   sendNestedJsonObj("sketchsize",  ESP.getSketchSize());
-  sendNestedJsonObj("freesketchspace",  ESP.getFreeSketchSpace() );
+  sendNestedJsonObj("freesketchspace", ESP.getFreeSketchSpace());
 
   snprintf(cMsg, sizeof(cMsg), "%08X", ESP.getFlashChipId());
   sendNestedJsonObj("flashchipid", cMsg);  // flashChipId
@@ -336,7 +336,7 @@ void sendDeviceInfo()
   sendNestedJsonObj("flashchiprealsize", (ESP.getFlashChipRealSize() / 1024.0f / 1024.0f));
 
   LittleFS.info(LittleFSinfo);
-  sendNestedJsonObj("LittleFSsize", floorf( (LittleFSinfo.totalBytes / (1024.0f * 1024.0f))));
+  sendNestedJsonObj("LittleFSsize", floorf((LittleFSinfo.totalBytes / (1024.0f * 1024.0f))));
 
   sendNestedJsonObj("flashchipspeed", floorf((ESP.getFlashChipSpeed() / 1000.0f / 1000.0f)));
 

--- a/restAPI.ino
+++ b/restAPI.ino
@@ -327,7 +327,7 @@ void sendDeviceInfo()
   sendNestedJsonObj("coreversion", CSTR(ESP.getCoreVersion()) );
   sendNestedJsonObj("sdkversion",  ESP.getSdkVersion());
   sendNestedJsonObj("cpufreq", ESP.getCpuFreqMHz());
-  sendNestedJsonObj("sketchsize",  ESP.getSketchSize());
+  sendNestedJsonObj("sketchsize", ESP.getSketchSize());
   sendNestedJsonObj("freesketchspace", ESP.getFreeSketchSpace());
 
   snprintf(cMsg, sizeof(cMsg), "%08X", ESP.getFlashChipId());


### PR DESCRIPTION
Remove the use of formatFloat function. This whole chain did a 
float -> double -> float -> string(alloc) -> float (dealloc string) -> string 
(the previous formatFloat fix removed last float conversion)

This is now reduced to:

float->string 
conversion.
