### PR TITLE
added provisions for password field

### DIFF
--- a/data/index.js
+++ b/data/index.js
@@ -514,6 +514,12 @@
                       sInput.setAttribute("maxlength", data[i].maxlen);
                       sInput.setAttribute("size", (data[i].maxlen > 20 ? 20 : data[i].maxlen));
                     }
+                    else if (data[i].type == "p")
+                    {
+                      sInput.setAttribute("type", "password");
+                      sInput.setAttribute("maxlength", data[i].maxlen);
+                      sInput.setAttribute("size", (data[i].maxlen > 20 ? 20 : data[i].maxlen));
+                    }
                     else if (data[i].type == "f")
                     {
                       sInput.setAttribute("type", "number");


### PR DESCRIPTION
Added frontend support for the password field type. Specifically for the MQTT password., but will work with any other field deemed sensitive by changing the data type to 'p' instead of 's'.