### PR TITLE
Throttle gateway-mode queries (firmware cache + UI de-duplication)

### DIFF
--- a/src/OTGW-firmware/OTGW-Core.ino
+++ b/src/OTGW-firmware/OTGW-Core.ino
@@ -183,9 +183,20 @@ This provides a reliable way to detect the actual configured mode,
 rather than inferring it from message traffic.
 */
 bool queryOTGWgatewaymode(){
+  static uint32_t lastGatewayModeQueryMs = 0;
+  static bool cachedGatewayMode = false;
+  static bool hasCachedGatewayMode = false;
+  constexpr uint32_t GATEWAY_MODE_QUERY_MIN_INTERVAL_MS = 60000; // hard throttle: max one PR=M per minute
+
   if (!bPICavailable) {
     OTGWDebugTln(F("queryOTGWgatewaymode: PIC not available"));
     return false;
+  }
+
+  const uint32_t now = millis();
+  if (hasCachedGatewayMode && ((uint32_t)(now - lastGatewayModeQueryMs) < GATEWAY_MODE_QUERY_MIN_INTERVAL_MS)) {
+    OTGWDebugTf(PSTR("queryOTGWgatewaymode: throttled, using cached value [%s]\r\n"), CCONOFF(cachedGatewayMode));
+    return cachedGatewayMode;
   }
   
   String response = executeCommand("PR=M");
@@ -212,6 +223,10 @@ bool queryOTGWgatewaymode(){
   } else {
     OTGWDebugTln(F("queryOTGWgatewaymode: Empty response, defaulting to false"));
   }
+
+  cachedGatewayMode = isGatewayMode;
+  hasCachedGatewayMode = true;
+  lastGatewayModeQueryMs = now;
   
   return isGatewayMode;
 }

--- a/src/OTGW-firmware/data/index.css
+++ b/src/OTGW-firmware/data/index.css
@@ -671,6 +671,32 @@
   background: #f44336;
 }
 
+.status-separator {
+  opacity: 0.6;
+}
+
+.mode-status {
+  display: inline-block;
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+  transition: all 0.3s ease;
+}
+
+.mode-gateway {
+  background: #ff9800;
+  box-shadow: 0 0 8px #ff9800;
+}
+
+.mode-monitor {
+  background: #2196f3;
+  box-shadow: 0 0 8px #2196f3;
+}
+
+.mode-unknown {
+  background: #9e9e9e;
+}
+
 /* Log Controls */
 .ot-log-controls {
   display: flex;

--- a/src/OTGW-firmware/data/index.html
+++ b/src/OTGW-firmware/data/index.html
@@ -55,6 +55,9 @@
           <div class="ot-log-status">
             <span id="wsStatus" class="ws-status ws-disconnected">●</span>
             <span id="wsStatusText">Disconnected</span>
+            <span class="status-separator">|</span>
+            <span id="gatewayModeStatus" class="mode-status mode-unknown">●</span>
+            <span id="gatewayModeText" title="Gateway mode values: Gateway (GW=1/on), Monitor (GW=0/off)">Mode: Unknown</span>
           </div>
         </div>
         

--- a/src/OTGW-firmware/data/index.js
+++ b/src/OTGW-firmware/data/index.js
@@ -39,8 +39,9 @@ document.addEventListener('visibilitychange', function () {
   // When tab becomes visible again, resume UI updates
   if (!flashModeActive) {
     refreshDevTime();
+    refreshGatewayMode(true);
     if (!timeupdate) {
-      timeupdate = setInterval(function () { refreshDevTime(); }, 1000);
+      timeupdate = setInterval(function () { refreshDevTime(); refreshGatewayMode(false); }, 1000);
     }
     // Ensure WebSocket is connected (will reconnect if needed)
     initOTLogWebSocket();
@@ -53,6 +54,84 @@ document.addEventListener('visibilitychange', function () {
 
 var tid = 0;
 var timeupdate = null; // Will be started when needed
+
+let gatewayModeLastFetchMs = 0;
+let gatewayModeFetchInFlight = false;
+const GATEWAY_MODE_REFRESH_INTERVAL_MS = 60000; // hard throttle: max one fetch per minute
+
+function updateGatewayModeIndicator(value) {
+  const statusEl = document.getElementById('gatewayModeStatus');
+  const textEl = document.getElementById('gatewayModeText');
+  if (!statusEl || !textEl) return;
+
+  if (value === true) {
+    statusEl.className = 'mode-status mode-gateway';
+    textEl.textContent = 'Mode: Gateway';
+  } else if (value === false) {
+    statusEl.className = 'mode-status mode-monitor';
+    textEl.textContent = 'Mode: Monitor';
+  } else {
+    statusEl.className = 'mode-status mode-unknown';
+    textEl.textContent = 'Mode: Unknown';
+  }
+}
+
+function parseGatewayModeValue(gatewayModeValue) {
+  if (typeof gatewayModeValue !== 'string') return null;
+
+  const normalized = gatewayModeValue.trim().toLowerCase();
+  if (normalized === 'on' || normalized === '1' || normalized === 'true' || normalized === 'gateway') {
+    return true;
+  }
+  if (normalized === 'off' || normalized === '0' || normalized === 'false' || normalized === 'monitor' || normalized === 'standalone') {
+    return false;
+  }
+  return null;
+}
+
+function updateGatewayModeFromDevInfoEntries(entries) {
+  let gatewayModeValue = null;
+
+  for (let i = 0; i < entries.length; i++) {
+    if (entries[i].name === 'gatewaymode') {
+      gatewayModeValue = entries[i].value;
+      break;
+    }
+  }
+
+  updateGatewayModeIndicator(parseGatewayModeValue(gatewayModeValue));
+}
+
+function refreshGatewayMode(_force) {
+  if (flashModeActive || !isPageVisible()) return;
+
+  const now = Date.now();
+  if (gatewayModeFetchInFlight) return;
+  if ((now - gatewayModeLastFetchMs) < GATEWAY_MODE_REFRESH_INTERVAL_MS) return;
+
+  gatewayModeFetchInFlight = true;
+
+  fetch(APIGW + 'v0/devinfo')
+    .then(response => {
+      if (!response.ok) {
+        throw new Error(`HTTP ${response.status}: ${response.statusText}`);
+      }
+      return response.json();
+    })
+    .then(json => {
+      const entries = (json && json.devinfo) ? json.devinfo : [];
+      updateGatewayModeFromDevInfoEntries(entries);
+      gatewayModeLastFetchMs = Date.now();
+    })
+    .catch(error => {
+      console.warn('refreshGatewayMode warning:', error);
+      updateGatewayModeIndicator(null);
+      gatewayModeLastFetchMs = Date.now();
+    })
+    .finally(() => {
+      gatewayModeFetchInFlight = false;
+    });
+}
 
 //============================================================================
 // Flash Mode Management - stops all background activity during flashing
@@ -83,7 +162,7 @@ function exitFlashMode() {
   
   // Restart time update
   if (!timeupdate) {
-    timeupdate = setInterval(function () { refreshDevTime(); }, 1000);
+    timeupdate = setInterval(function () { refreshDevTime(); refreshGatewayMode(false); }, 1000);
   }
   
   // Restart WebSocket if on main page
@@ -2123,7 +2202,8 @@ function initMainPage() {
   // Start time updates if not in flash mode
   if (!flashModeActive && !timeupdate) {
     refreshDevTime();
-    timeupdate = setInterval(function () { refreshDevTime(); }, 1000);
+    refreshGatewayMode(true);
+    timeupdate = setInterval(function () { refreshDevTime(); refreshGatewayMode(false); }, 1000);
   }
 
   if (window.location.hash == "#tabPICflash") {
@@ -2143,6 +2223,7 @@ function showMainPage() {
   }
   
   refreshDevTime();
+  refreshGatewayMode(true);
   
   document.getElementById("displayMainPage").classList.add('active');
   document.getElementById("displaySettingsPage").classList.remove('active');
@@ -2500,6 +2581,9 @@ function refreshDevInfo() {
           ipaddress = data[i].value;
         }
       }
+
+      updateGatewayModeFromDevInfoEntries(data);
+      gatewayModeLastFetchMs = Date.now();
 
       const versionEl = document.getElementById('devVersion');
       if (versionEl) versionEl.textContent = version;
@@ -3231,7 +3315,7 @@ function handleFlashCompletion(filename, error) {
     
     // Restart polling
     if (!tid) tid = setInterval(function () { refreshOTmonitor(); }, 1000);
-    if (!timeupdate) timeupdate = setInterval(function () { refreshDevTime(); }, 1000);
+    if (!timeupdate) timeupdate = setInterval(function () { refreshDevTime(); refreshGatewayMode(false); }, 1000);
 }
 
 function handleFlashError(filename, error) {
@@ -3247,7 +3331,7 @@ function handleFlashError(filename, error) {
     
     // Restart polling
     if (!tid) tid = setInterval(function () { refreshOTmonitor(); }, 1000);
-    if (!timeupdate) timeupdate = setInterval(function () { refreshDevTime(); }, 1000);
+    if (!timeupdate) timeupdate = setInterval(function () { refreshDevTime(); refreshGatewayMode(false); }, 1000);
 }
 
 // function pollForReboot() - Removed
@@ -3295,7 +3379,7 @@ function performFlash(filename) {
                 toggleInteraction(true);
                 // Restart polling
                 if (!tid) tid = setInterval(function () { refreshOTmonitor(); }, 1000);
-                if (!timeupdate) timeupdate = setInterval(function () { refreshDevTime(); }, 1000);
+                if (!timeupdate) timeupdate = setInterval(function () { refreshDevTime(); refreshGatewayMode(false); }, 1000);
                 return;
              }
 
@@ -3329,7 +3413,7 @@ function performFlash(filename) {
                     
                     // Restart polling on start failure
                     if (!tid) tid = setInterval(function () { refreshOTmonitor(); }, 1000);
-                    if (!timeupdate) timeupdate = setInterval(function () { refreshDevTime(); }, 1000);
+                    if (!timeupdate) timeupdate = setInterval(function () { refreshDevTime(); refreshGatewayMode(false); }, 1000);
                 });
         }
     }, 100);
@@ -3398,7 +3482,7 @@ function handleFlashMessage(data) {
                 
                 // Restart polling
                 if (!tid) tid = setInterval(function () { refreshOTmonitor(); }, 1000);
-                if (!timeupdate) timeupdate = setInterval(function () { refreshDevTime(); }, 1000);
+                if (!timeupdate) timeupdate = setInterval(function () { refreshDevTime(); refreshGatewayMode(false); }, 1000);
             } else if (msg.state === 'error' || msg.state === 'abort') {
                 // Error or abort
                 stopFlashPolling(); // Stop failsafe polling
@@ -3412,7 +3496,7 @@ function handleFlashMessage(data) {
                 
                 // Restart polling
                 if (!tid) tid = setInterval(function () { refreshOTmonitor(); }, 1000);
-                if (!timeupdate) timeupdate = setInterval(function () { refreshDevTime(); }, 1000);
+                if (!timeupdate) timeupdate = setInterval(function () { refreshDevTime(); refreshGatewayMode(false); }, 1000);
             }
             
             return true; // It was a flash message

--- a/src/OTGW-firmware/data/index_dark.css
+++ b/src/OTGW-firmware/data/index_dark.css
@@ -671,6 +671,32 @@
   background: #f44336;
 }
 
+.status-separator {
+  opacity: 0.6;
+}
+
+.mode-status {
+  display: inline-block;
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+  transition: all 0.3s ease;
+}
+
+.mode-gateway {
+  background: #ff9800;
+  box-shadow: 0 0 8px #ff9800;
+}
+
+.mode-monitor {
+  background: #2196f3;
+  box-shadow: 0 0 8px #2196f3;
+}
+
+.mode-unknown {
+  background: #9e9e9e;
+}
+
 /* Log Controls */
 .ot-log-controls {
   display: flex;


### PR DESCRIPTION
### Motivation
- Prevent redundant or rapid `PR=M` queries to the PIC that may be triggered by UI flows or concurrent code paths. 
- Ensure the web UI does not double-request the same gateway mode value in quick succession. 
- Reduce unnecessary serial/API traffic and avoid forcing expensive or repeated device queries.

### Description
- In firmware, `queryOTGWgatewaymode()` now uses static cache state and a `GATEWAY_MODE_QUERY_MIN_INTERVAL_MS = 60000` timestamp to return a cached value if called again within 60s, and only sends `PR=M` when allowed. 
- In the UI, the old counter-based approach was replaced with `gatewayModeLastFetchMs`, `gatewayModeFetchInFlight`, and `GATEWAY_MODE_REFRESH_INTERVAL_MS = 60000` to enforce a one-per-minute minimum and prevent concurrent fetches. 
- `refreshDevInfo()` now updates the gateway indicator via `updateGatewayModeFromDevInfoEntries()` and sets `gatewayModeLastFetchMs` to avoid an immediate duplicate `refreshGatewayMode()` fetch. 
- Added UI elements and styling for the status indicator (`#gatewayModeStatus`, `#gatewayModeText`) and CSS classes `.mode-status`, `.mode-gateway`, `.mode-monitor`, and `.mode-unknown`, while keeping API payloads and field names unchanged.

### Testing
- Ran `node --check src/OTGW-firmware/data/index.js` which completed successfully. 
- Verified presence of the new identifiers and messages using `rg` for `gatewayModeLastFetchMs|gatewayModeFetchInFlight|GATEWAY_MODE_QUERY_MIN_INTERVAL_MS|throttled, using cached`. 
- Performed code inspection to confirm firmware caching in `queryOTGWgatewaymode()` and UI de-duplication in `refreshGatewayMode()` and `refreshDevInfo()`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69898b6833d8832491de83cde89f04ea)