### PR TITLE
Fix WiFi reconnection during OTA updates and filesystem flashing

### DIFF
--- a/src/OTGW-firmware/OTGW-ModUpdateServer-impl.h
+++ b/src/OTGW-firmware/OTGW-ModUpdateServer-impl.h
@@ -175,7 +175,7 @@ void ESP8266HTTPUpdateServerTemplate<ServerType>::setup(ESP8266WebServerTemplate
           if (uploadTotal > 0 && uploadTotal > fsSize) {
             _updaterError = F("filesystem image too large");
             _setStatus(UPDATE_ERROR, "filesystem", 0, uploadTotal, upload.filename, _updaterError);
-          } else if (!Update.begin(uploadTotal > 0 ? uploadTotal : fsSize, U_FS)){//start with max available size
+          } else if (!Update.begin(fsSize, U_FS)){//always use full partition size to erase stale old-filesystem data in upper blocks
             if (_serial_output) Update.printError(OTGWSerial);
             _setUpdaterError();
             _setStatus(UPDATE_ERROR, "filesystem", 0, uploadTotal, upload.filename, _updaterError);

--- a/src/OTGW-firmware/OTGW-firmware.ino
+++ b/src/OTGW-firmware/OTGW-firmware.ino
@@ -441,7 +441,15 @@ void doBackgroundTasks()
   // blinkLED/delayms in setup() would otherwise invoke handleMQTT() before
   // startMQTT() sets the 1350-byte buffer, and handleOTGW() before resetOTGW().
   if (!state.bSetupComplete) return;
-  loopWifi();                   // Non-blocking WiFi reconnect state machine (ADR-047)
+  // ADR-047: Non-blocking WiFi reconnect state machine.
+  // Guard: skip during any flash operation (ESP or PIC).
+  // During Update.write() the ESP8266 suspends flash reads, starving the WiFi
+  // stack. After the write, WiFi.status() may transiently return WL_DISCONNECTED,
+  // causing loopWifi() to initiate a reconnect mid-upload. If the reconnect
+  // completes while the upload is still in progress, WIFI_RECONNECTED calls
+  // startWebSocket()/startMQTT(), potentially tearing down the HTTP connection
+  // carrying the OTA data and leaving the LittleFS partition partially written.
+  if (!isFlashing()) loopWifi();
 
   // Check for critically low heap and attempt recovery if needed
   if (getHeapHealth() == HEAP_CRITICAL) {


### PR DESCRIPTION
## Summary
This PR fixes critical issues that can corrupt firmware and filesystem updates by preventing WiFi reconnection attempts during flash operations, and ensures the full filesystem partition is erased during updates.

## Key Changes

- **Guard WiFi reconnection during flash operations**: Added a check in `doBackgroundTasks()` to skip `loopWifi()` when any flash operation is in progress (ESP or PIC). This prevents the WiFi stack from initiating reconnections mid-upload, which could tear down the HTTP connection carrying OTA data and leave partitions partially written.

- **Always use full partition size for filesystem updates**: Changed `Update.begin()` to always use the full filesystem partition size (`fsSize`) instead of the uploaded file size. This ensures stale data in upper blocks of the old filesystem is properly erased during updates, preventing corruption from leftover files.

## Implementation Details

The WiFi reconnection guard works by:
1. During `Update.write()`, the ESP8266 suspends flash reads, starving the WiFi stack
2. After the write, `WiFi.status()` may transiently return `WL_DISCONNECTED`
3. Without the guard, `loopWifi()` would initiate a reconnect mid-upload
4. If the reconnect completes while upload is in progress, `WIFI_RECONNECTED` would call `startWebSocket()/startMQTT()`, potentially tearing down the HTTP connection

The filesystem update fix ensures that when a smaller filesystem image is uploaded, the entire partition is erased rather than leaving stale data in unused blocks, which could cause unexpected behavior or data corruption.

https://claude.ai/code/session_01AyuaWfLWwDx4Gqb32Dzb1t