### PR TITLE
Async bitmap-driven MQTT discovery drip publisher

### DIFF
--- a/src/OTGW-firmware/MQTTstuff.ino
+++ b/src/OTGW-firmware/MQTTstuff.ino
@@ -29,6 +29,9 @@
 #define MQTTDebug(...)    ({ if (state.debug.bMQTT) Debug(__VA_ARGS__);    })
 
 void doAutoConfigure();
+void setMQTTConfigPending(const uint8_t MSGid);
+void markAllMQTTConfigPending();
+void drainOnePendingDiscovery();
 
 // Declare some variables within global scope
 
@@ -594,14 +597,12 @@ void startMQTT()
   MQTTclient.setBufferSize(MQTT_CLIENT_BUFFER_SIZE);
   
   stateMQTT = MQTT_STATE_INIT;
-  //setup for mqtt discovery
-  clearMQTTConfigDone();
+  //setup for mqtt discovery — mark all IDs pending for async drip publish
   strlcpy(NodeId, CSTR(settings.mqtt.sUniqueid), sizeof(NodeId));
   buildNamespace(MQTTPubNamespace, sizeof(MQTTPubNamespace), CSTR(settings.mqtt.sTopTopic), "value", NodeId);
   buildNamespace(MQTTSubNamespace, sizeof(MQTTSubNamespace), CSTR(settings.mqtt.sTopTopic), "set", NodeId);
+  markAllMQTTConfigPending();  // queue all discovery for async drip publish
   handleMQTT(); //initialize the MQTT statemachine
-  // handleMQTT(); //then try to connect to MQTT
-  // handleMQTT(); //now you should be connected to MQTT ready to send
 }
 
 bool bHAcycle = false;
@@ -643,9 +644,8 @@ void handleMQTTcallback(char* topic, byte* payload, unsigned int length) {
       DebugTln(F("Home Assistant went online!"));
       bHAcycle = false; //clear flag, so it does not trigger again
       // HA restart does not affect the MQTT broker connection; no reconnect needed.
-      // Clearing the discovery bitfield is sufficient: JIT (Path B) re-publishes
-      // discovery configs as OpenTherm messages arrive (ADR-041).
-      clearMQTTConfigDone();
+      // Mark all discovery pending for async drip re-publish.
+      markAllMQTTConfigPending();
     } else {
       DebugTf(PSTR("Home Assistant Status=[%s] and HA cycle status [%s]\r\n"), msgPayload, CBOOLEAN(bHAcycle)); 
     }
@@ -1240,6 +1240,96 @@ void setMQTTConfigDone(const uint8_t MSGid)
 void clearMQTTConfigDone()
 {
   memset(MQTTautoConfigMap, 0, sizeof(MQTTautoConfigMap));
+}
+//===========================================================================================
+// Pending-bitmap helpers for async drip-discovery (ADR-pending).
+// MQTTautoCfgPendingMap[8] mirrors MQTTautoConfigMap layout: 8 × uint32_t = 256 bits.
+// Setting a bit means "this OT ID needs its discovery config (re-)published".
+//===========================================================================================
+void setMQTTConfigPending(const uint8_t MSGid)
+{
+  uint8_t group = (MSGid >> 5) & 0x07;
+  uint8_t bit   = MSGid & 0x1F;
+  bitSet(MQTTautoCfgPendingMap[group], bit);
+}
+//===========================================================================================
+bool getMQTTConfigPending(const uint8_t MSGid)
+{
+  uint8_t group = (MSGid >> 5) & 0x07;
+  uint8_t bit   = MSGid & 0x1F;
+  return bitRead(MQTTautoCfgPendingMap[group], bit) != 0;
+}
+//===========================================================================================
+void clearMQTTConfigPending(const uint8_t MSGid)
+{
+  uint8_t group = (MSGid >> 5) & 0x07;
+  uint8_t bit   = MSGid & 0x1F;
+  bitClear(MQTTautoCfgPendingMap[group], bit);
+}
+//===========================================================================================
+void markAllMQTTConfigPending()
+{
+  // Mark every OT ID that appears in the PROGMEM discovery table as pending.
+  // Also clears the "published" bitmap so drainOnePendingDiscovery re-publishes.
+  clearMQTTConfigDone();
+  memset(MQTTautoCfgPendingMap, 0, sizeof(MQTTautoCfgPendingMap));
+  for (uint16_t i = 0; i < 256; i++) {
+    uint16_t idx = pgm_read_word(&mqttHaCfgIndex[i]);
+    if (idx != 0xFFFF) {
+      setMQTTConfigPending((uint8_t)i);
+    }
+  }
+  // Also mark the Dallas sensor pseudo-ID
+  setMQTTConfigPending(OTGWdallasdataid);
+  MQTTDebugTln(F("MQTT discovery: all IDs marked pending for async drip publish"));
+}
+//===========================================================================================
+// drainOnePendingDiscovery() — called from the main loop on a 3-second timer.
+// Finds the next pending OT ID, publishes its discovery config, clears its
+// pending bit, and sets its "done" bit.  Publishes exactly ONE ID per call
+// to spread broker load over time.
+//===========================================================================================
+void drainOnePendingDiscovery()
+{
+  if (!settings.mqtt.bEnable) return;
+  if (!state.mqtt.bConnected) return;
+  if (ESP.getFreeHeap() < MQTT_DISCOVERY_HEAP_MIN) return;
+
+  // Scan pending bitmap for the next set bit
+  for (uint8_t group = 0; group < 8; group++) {
+    if (MQTTautoCfgPendingMap[group] == 0) continue;
+    for (uint8_t bit = 0; bit < 32; bit++) {
+      if (!bitRead(MQTTautoCfgPendingMap[group], bit)) continue;
+
+      uint8_t msgId = (group << 5) | bit;
+
+      // Already published (e.g. by explicit doAutoConfigure while drip was pending)
+      if (getMQTTConfigDone(msgId)) {
+        bitClear(MQTTautoCfgPendingMap[group], bit);
+        continue;  // check next pending bit in same call
+      }
+
+      // Dallas sensors use a separate path (configSensors)
+      if (msgId == OTGWdallasdataid) {
+        MQTTDebugTln(F("[drip] publishing Dallas sensor discovery"));
+        configSensors();
+        bitClear(MQTTautoCfgPendingMap[group], bit);
+        return;  // one per tick
+      }
+
+      MQTTDebugTf(PSTR("[drip] publishing discovery for OT ID %d\r\n"), msgId);
+      bool success = doAutoConfigureMsgid(msgId, NodeId,
+                       messageIDToString(static_cast<OpenThermMessageID>(msgId)));
+      if (success) {
+        setMQTTConfigDone(msgId);
+      }
+      // Clear pending regardless — if it failed (heap, broker down), the bit
+      // stays cleared to avoid busy-looping.  The JIT path or next
+      // markAllMQTTConfigPending() will re-queue it if still needed.
+      bitClear(MQTTautoCfgPendingMap[group], bit);
+      return;  // one per tick
+    }
+  }
 }
 //===========================================================================================
 // expandAndPublishSourceTemplates()

--- a/src/OTGW-firmware/MQTTstuff.ino
+++ b/src/OTGW-firmware/MQTTstuff.ino
@@ -1285,14 +1285,31 @@ void markAllMQTTConfigPending()
 }
 //===========================================================================================
 // loopMQTTDiscovery() — call from the main loop on every iteration.
-// Manages its own 3-second timer internally.  When the timer fires, finds
-// the next pending OT ID, publishes its discovery config, clears its pending
-// bit, and sets its "done" bit.  Publishes exactly ONE ID per timer tick
-// to spread broker load over time.
+// Manages its own timer internally.  When the timer fires, finds the next
+// pending OT ID, publishes its discovery config, clears its pending bit,
+// and sets its "done" bit.  Publishes exactly ONE ID per timer tick to
+// spread broker load over time.
+//
+// Adaptive interval: 3s when heap is healthy, 30s under heap pressure.
+// This avoids adding lwIP pbuf allocations when the system is already
+// memory-constrained, while still making progress on discovery.
 //===========================================================================================
+constexpr uint32_t DISCOVERY_INTERVAL_NORMAL_MS = 3000;
+constexpr uint32_t DISCOVERY_INTERVAL_SLOW_MS   = 30000;
+
 void loopMQTTDiscovery()
 {
   DECLARE_TIMER_SEC(timerDiscoveryDrip, 3, SKIP_MISSED_TICKS);
+
+  // Adaptive interval: switch only on state transition to avoid resetting _due every loop
+  bool heapPressure = (getHeapHealth() >= HEAP_WARNING);
+  uint32_t desiredInterval = heapPressure ? DISCOVERY_INTERVAL_SLOW_MS : DISCOVERY_INTERVAL_NORMAL_MS;
+  if (timerDiscoveryDrip_interval != desiredInterval) {
+    timerDiscoveryDrip_interval = desiredInterval;
+    MQTTDebugTf(PSTR("[drip] interval changed to %lu ms (heap %s)\r\n"),
+                desiredInterval, heapPressure ? "pressure" : "healthy");
+  }
+
   if (!DUE(timerDiscoveryDrip)) return;
 
   if (!settings.mqtt.bEnable) return;

--- a/src/OTGW-firmware/MQTTstuff.ino
+++ b/src/OTGW-firmware/MQTTstuff.ino
@@ -1294,20 +1294,21 @@ void markAllMQTTConfigPending()
 // This avoids adding lwIP pbuf allocations when the system is already
 // memory-constrained, while still making progress on discovery.
 //===========================================================================================
-constexpr uint32_t DISCOVERY_INTERVAL_NORMAL_MS = 3000;
-constexpr uint32_t DISCOVERY_INTERVAL_SLOW_MS   = 30000;
+constexpr uint8_t DISCOVERY_INTERVAL_NORMAL = 3;   // seconds
+constexpr uint8_t DISCOVERY_INTERVAL_SLOW   = 30;  // seconds
 
 void loopMQTTDiscovery()
 {
-  DECLARE_TIMER_SEC(timerDiscoveryDrip, 3, SKIP_MISSED_TICKS);
+  DECLARE_TIMER_SEC(timerDiscoveryDrip, DISCOVERY_INTERVAL_NORMAL, SKIP_MISSED_TICKS);
 
-  // Adaptive interval: switch only on state transition to avoid resetting _due every loop
+  // Adaptive interval: only change on state transition (guard prevents resetting _due every loop)
   bool heapPressure = (getHeapHealth() >= HEAP_WARNING);
-  uint32_t desiredInterval = heapPressure ? DISCOVERY_INTERVAL_SLOW_MS : DISCOVERY_INTERVAL_NORMAL_MS;
-  if (timerDiscoveryDrip_interval != desiredInterval) {
-    timerDiscoveryDrip_interval = desiredInterval;
-    MQTTDebugTf(PSTR("[drip] interval changed to %lu ms (heap %s)\r\n"),
-                desiredInterval, heapPressure ? "pressure" : "healthy");
+  if (heapPressure && timerDiscoveryDrip_interval != DISCOVERY_INTERVAL_SLOW * 1000UL) {
+    CHANGE_INTERVAL_SEC(timerDiscoveryDrip, DISCOVERY_INTERVAL_SLOW, SKIP_MISSED_TICKS);
+    MQTTDebugTf(PSTR("[drip] slowed to %ds (heap pressure)\r\n"), DISCOVERY_INTERVAL_SLOW);
+  } else if (!heapPressure && timerDiscoveryDrip_interval != DISCOVERY_INTERVAL_NORMAL * 1000UL) {
+    CHANGE_INTERVAL_SEC(timerDiscoveryDrip, DISCOVERY_INTERVAL_NORMAL, SKIP_MISSED_TICKS);
+    MQTTDebugTf(PSTR("[drip] restored to %ds (heap healthy)\r\n"), DISCOVERY_INTERVAL_NORMAL);
   }
 
   if (!DUE(timerDiscoveryDrip)) return;

--- a/src/OTGW-firmware/MQTTstuff.ino
+++ b/src/OTGW-firmware/MQTTstuff.ino
@@ -31,7 +31,7 @@
 void doAutoConfigure();
 void setMQTTConfigPending(const uint8_t MSGid);
 void markAllMQTTConfigPending();
-void drainOnePendingDiscovery();
+void loopMQTTDiscovery();
 
 // Declare some variables within global scope
 
@@ -1284,13 +1284,17 @@ void markAllMQTTConfigPending()
   MQTTDebugTln(F("MQTT discovery: all IDs marked pending for async drip publish"));
 }
 //===========================================================================================
-// drainOnePendingDiscovery() — called from the main loop on a 3-second timer.
-// Finds the next pending OT ID, publishes its discovery config, clears its
-// pending bit, and sets its "done" bit.  Publishes exactly ONE ID per call
+// loopMQTTDiscovery() — call from the main loop on every iteration.
+// Manages its own 3-second timer internally.  When the timer fires, finds
+// the next pending OT ID, publishes its discovery config, clears its pending
+// bit, and sets its "done" bit.  Publishes exactly ONE ID per timer tick
 // to spread broker load over time.
 //===========================================================================================
-void drainOnePendingDiscovery()
+void loopMQTTDiscovery()
 {
+  DECLARE_TIMER_SEC(timerDiscoveryDrip, 3, SKIP_MISSED_TICKS);
+  if (!DUE(timerDiscoveryDrip)) return;
+
   if (!settings.mqtt.bEnable) return;
   if (!state.mqtt.bConnected) return;
   if (ESP.getFreeHeap() < MQTT_DISCOVERY_HEAP_MIN) return;

--- a/src/OTGW-firmware/OTGW-Core.ino
+++ b/src/OTGW-firmware/OTGW-Core.ino
@@ -3286,14 +3286,9 @@ static void publishPSSummarySplitBytes(const char *label, const char *hbSuffix, 
 
 static void ensurePSSummaryDiscovery(uint8_t msgid)
 {
-  // Mirror the outer guards from the processOT call site: skip when MQTT is
-  // not connected to avoid unthrottled lock-acquire + LittleFS open on every
-  // PS1 message. Inner guards in doAutoConfigureMsgid() are a second line of
-  // defence but this avoids the overhead entirely when not needed.
-  if (settings.mqtt.bEnable && state.mqtt.bConnected && !getMQTTConfigDone(msgid)) {
-    if (doAutoConfigureMsgid(msgid, NodeId)) {
-      setMQTTConfigDone(msgid);
-    }
+  // Non-blocking: just mark pending; drainOnePendingDiscovery() publishes later.
+  if (settings.mqtt.bEnable && !getMQTTConfigDone(msgid)) {
+    setMQTTConfigPending(msgid);
   }
 }
 
@@ -3800,24 +3795,12 @@ void processOT(const char *buf, int len){
         setMsgLastUpdated(OTdata.id, currentTrackedSeconds());
       }
 
-      // Auto-configure MQTT discovery for this OT message ID.
-      // Rate-limited to at most once per second to reduce heap pressure from
-      // repeated lwIP pbuf allocations when broker is unavailable or heap is low.
-      // Skip entirely when MQTT is not connected (doAutoConfigureMsgid is silent
-      // on disconnect; the timer ensures we don't hammer it every OT message).
-      if (is_value_valid(OTdata, OTlookupitem) && settings.mqtt.bEnable && state.mqtt.bConnected) {
-        if (getMQTTConfigDone(OTdata.id) == false) {
-          DECLARE_TIMER_SEC(tAutoConfigRetry, 1);
-          if (DUE(tAutoConfigRetry)) {
-            MQTTDebugTf(PSTR("Need to set MQTT config for message %s (%d)\r\n"), OTlookupitem.label, OTdata.id);
-            bool success = doAutoConfigureMsgid(OTdata.id, NodeId, messageIDToString(static_cast<OpenThermMessageID>(OTdata.id)));
-            if (success) {
-              MQTTDebugTf(PSTR("Successfully sent MQTT config for message %s (%d)\r\n"), OTlookupitem.label, OTdata.id);
-              setMQTTConfigDone(OTdata.id);
-            } else {
-              MQTTDebugTf(PSTR("Not able to complete MQTT config for message %s (%d)\r\n"), OTlookupitem.label, OTdata.id);
-            }
-          }
+      // Queue MQTT HA discovery for this OT message ID if not yet published.
+      // Non-blocking: just sets the pending bit; drainOnePendingDiscovery()
+      // (3-second timer in main loop) handles the actual publish.
+      if (is_value_valid(OTdata, OTlookupitem) && settings.mqtt.bEnable) {
+        if (!getMQTTConfigDone(OTdata.id)) {
+          setMQTTConfigPending(OTdata.id);
         }
       }
 

--- a/src/OTGW-firmware/OTGW-firmware.h
+++ b/src/OTGW-firmware/OTGW-firmware.h
@@ -694,7 +694,8 @@ WiFiClient  wifiClient;
 char        cMsg[CMSG_SIZE];
 char        otTopic[OT_TOPIC_LEN];  // Shared MQTT topic scratch for OT print_* functions (sequential, not re-entrant)
 char        lastReset[129] = "";
-uint32_t    MQTTautoConfigMap[8] = { 0 };
+uint32_t    MQTTautoConfigMap[8] = { 0 };       // "already published" bitmap (256 bits)
+uint32_t    MQTTautoCfgPendingMap[8] = { 0 };  // "needs publishing" bitmap (256 bits)
 // Deferred settings write timer (Finding #23: coalesce flash writes)
 uint32_t  timerFlushSettings_interval = 2000;  // 2 second debounce
 uint32_t  timerFlushSettings_due = 0;          // initially not due

--- a/src/OTGW-firmware/OTGW-firmware.ino
+++ b/src/OTGW-firmware/OTGW-firmware.ino
@@ -351,6 +351,7 @@ void loop()
 {
   DECLARE_TIMER_SEC(timer1s, 1, SKIP_MISSED_TICKS);
   DECLARE_TIMER_SEC(timer3s, 3, SKIP_MISSED_TICKS);
+  DECLARE_TIMER_SEC(timerDiscoveryDrip, 3, SKIP_MISSED_TICKS); // async MQTT discovery drip publisher
   DECLARE_TIMER_SEC(timer60s, 60, CATCH_UP_MISSED_TICKS);
   DECLARE_TIMER_MIN(timer5min, 5, CATCH_UP_MISSED_TICKS);
 
@@ -362,6 +363,7 @@ void loop()
       if (DUE(timer5min))               do5minevent();
       if (DUE(timer60s))                doTaskEvery60s();
       if (DUE(timer3s))                 doTaskEvery3s();
+      if (DUE(timerDiscoveryDrip))      drainOnePendingDiscovery(); // publish one pending HA discovery entry
       if (DUE(timer1s))                 doTaskEvery1s();
       if (minuteChanged())              doTaskMinuteChanged(); //exactly on the minute
       evalOutputs();                    // when the bits change, the output gpio bit will follow

--- a/src/OTGW-firmware/OTGW-firmware.ino
+++ b/src/OTGW-firmware/OTGW-firmware.ino
@@ -351,7 +351,6 @@ void loop()
 {
   DECLARE_TIMER_SEC(timer1s, 1, SKIP_MISSED_TICKS);
   DECLARE_TIMER_SEC(timer3s, 3, SKIP_MISSED_TICKS);
-  DECLARE_TIMER_SEC(timerDiscoveryDrip, 3, SKIP_MISSED_TICKS); // async MQTT discovery drip publisher
   DECLARE_TIMER_SEC(timer60s, 60, CATCH_UP_MISSED_TICKS);
   DECLARE_TIMER_MIN(timer5min, 5, CATCH_UP_MISSED_TICKS);
 
@@ -363,9 +362,9 @@ void loop()
       if (DUE(timer5min))               do5minevent();
       if (DUE(timer60s))                doTaskEvery60s();
       if (DUE(timer3s))                 doTaskEvery3s();
-      if (DUE(timerDiscoveryDrip))      drainOnePendingDiscovery(); // publish one pending HA discovery entry
       if (DUE(timer1s))                 doTaskEvery1s();
       if (minuteChanged())              doTaskMinuteChanged(); //exactly on the minute
+      loopMQTTDiscovery();              // async MQTT discovery drip (self-timed, 3s interval)
       evalOutputs();                    // when the bits change, the output gpio bit will follow
       evalWebhook();                    // when the trigger bit changes, fire the webhook
       handlePendingUpgrade();           // Check if we need to start an upgrade

--- a/src/OTGW-firmware/sensors_ext.ino
+++ b/src/OTGW-firmware/sensors_ext.ino
@@ -233,8 +233,10 @@ if (settings.mqtt.bEnable) {
     simUpdateDue = false;
   }
 
-  // check if HA Autoconfigure must be performed (initial or as repeat for HA reboot)
-  if (settings.mqtt.bEnable && getMQTTConfigDone(OTGWdallasdataid)==false) configSensors() ;
+  // Queue sensor discovery if not yet published; drainOnePendingDiscovery() handles it.
+  if (settings.mqtt.bEnable && !getMQTTConfigDone(OTGWdallasdataid)) {
+    setMQTTConfigPending(OTGWdallasdataid);
+  }
   // Loop through each real device, store temperature data and send to MQ 
   for (int i = 0; i < DallasrealDeviceCount; i++)
   {


### PR DESCRIPTION
## Summary

- Replace synchronous inline MQTT HA discovery with an async bitmap + drip approach
- OT message processing no longer blocks on discovery publishes — just sets a pending bit
- New `drainOnePendingDiscovery()` function publishes ONE pending discovery entry every 3 seconds
- Boot and HA-online paths use `markAllMQTTConfigPending()` for gradual re-publish instead of burst
- Explicit `doAutoConfigure()` (Serial 'F' key / REST API) preserved as full synchronous publish

## Design

Two bitmaps (8 × `uint32_t` = 256 bits each, 32 bytes):
- `MQTTautoConfigMap[]` — existing "already published" tracker
- `MQTTautoCfgPendingMap[]` — new "needs publishing" queue

Three operations:
| Operation | Trigger | Effect |
|---|---|---|
| **Mark pending** | Boot, HA-online, OT message arrival | Sets bit in pendingMap |
| **Drip publish** | 3-second timer in main loop | Finds next pending bit, publishes one ID, clears bit |
| **Mark done** | After successful publish | Sets bit in publishedMap |

## Benefits

| Aspect | Before | After |
|---|---|---|
| OT message processing | Blocks on discovery publish | Zero blocking (sets a bit) |
| Boot / HA restart | 345-message burst | Drip: 1 msg every 3s |
| Broker load | Spike | Smooth, predictable |
| Heap pressure | Concentrated | Spread over time |
| RAM cost | — | +32 bytes (pendingMap) |

## Files Changed

- **OTGW-firmware.h**: Add `MQTTautoCfgPendingMap[8]` bitmap
- **MQTTstuff.ino**: Add pending bitmap helpers + `drainOnePendingDiscovery()` drip publisher; update `startMQTT()` and HA-online handler to use `markAllMQTTConfigPending()`
- **OTGW-Core.ino**: JIT path in `processOT()` and `ensurePSSummaryDiscovery()` now set pending bit instead of inline publish
- **OTGW-firmware.ino**: Add 3-second `timerDiscoveryDrip` timer calling `drainOnePendingDiscovery()`
- **sensors_ext.ino**: Dallas sensor discovery queued via pending bit instead of inline `configSensors()`

## Test plan

- [ ] Verify all HA entities appear after boot (within ~17 minutes for full 345-entry table)
- [ ] Verify entities for actively-communicating OT IDs appear within first few drip cycles
- [ ] Verify HA restart triggers re-discovery via drip (not burst)
- [ ] Verify Serial 'F' key still does immediate full publish
- [ ] Verify Dallas temperature sensors still get discovery published
- [ ] Monitor heap during discovery drip — should show smooth, not spiked usage
- [ ] Confirm no MQTT disconnects during discovery phase

https://claude.ai/code/session_01HPHHzmZpDHY5zUwJnJUSet