### PR TITLE
docs: fix dev documentation-review findings 1-5

### DIFF
--- a/.github/workflows/evaluate.yml
+++ b/.github/workflows/evaluate.yml
@@ -49,6 +49,8 @@ jobs:
             root / "docs" / "releases",
             root / "docs" / "api",
             root / "docs" / "features",
+            root / "docs" / "guides",
+            root / "docs" / "process",
           ]
           md_files = []
           for item in scope:

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # OTGW-firmware (ESP8266) for NodoShop OpenTherm Gateway
 
-> ✅ This branch tracks the stable/public release line.
-> For in-progress development changes, see the [`dev` branch](https://github.com/rvdbreemen/OTGW-firmware/tree/dev).
+> ⚠️ **This is the development branch (`dev`)** — the 1.5.x maintenance line, tracking the next `1.5.x` release.
+> For the current stable release, see the [`main` branch](https://github.com/rvdbreemen/OTGW-firmware/tree/main) or the [v1.5.0 release](https://github.com/rvdbreemen/OTGW-firmware/releases/tag/v1.5.0).
 
 [![Join the Discord chat](https://img.shields.io/discord/812969634638725140.svg?style=flat-square)](https://discord.gg/zjW3ju7vGQ)
 
@@ -21,7 +21,7 @@ v1.5.0 is the first stable release of the `1.5.x` long-term-support line on **Ar
 - **No-Python flash and build scripts**: `flash_otgw.sh` / `flash_otgw.bat` and `build.sh` / `build.bat`.
 - **Arduino Core 2.7.4 baseline**: partition layout retained at `eesz=4M2M` — no filesystem partition reformat needed when upgrading from v1.4.1.
 
-Full release notes: [RELEASE_NOTES_1.5.0.md](docs/releases/RELEASE_NOTES_1.5.0.md)
+Full release notes: [RELEASE_NOTES_1.5.0.md](docs/releases/RELEASE_NOTES_1.5.0.md)  
 Breaking changes: [docs/BREAKING_CHANGES.md](docs/BREAKING_CHANGES.md)
 
 ## Latest stable release: v1.5.0-fix2

--- a/backlog/tasks/task-605 - Fix-documentation-review-findings-1-5-on-dev.md
+++ b/backlog/tasks/task-605 - Fix-documentation-review-findings-1-5-on-dev.md
@@ -1,0 +1,26 @@
+---
+id: TASK-605
+title: Fix documentation review findings 1-5 on dev
+status: To Do
+assignee: []
+created_date: '2026-05-16 07:10'
+labels:
+  - documentation
+dependencies: []
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Address the 5 findings from the dev documentation review: README dev/stable banner self-contradiction, v1.3.5 archive-policy contradiction, CI link-check scope gap, broken ../ relative links in docs/guides, and cosmetic/translation nits.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 README.md banner correctly identifies dev as the development/1.5.x maintenance line (not 'stable/public release line')
+- [ ] #2 DOCUMENTATION_LINKS_POLICY.md rule 4 matches actual release-notes placement (v1.3.4 and older archived; v1.3.5/v1.4.1/v1.5.x current)
+- [ ] #3 .github/workflows/evaluate.yml link-check scope includes docs/guides and docs/process
+- [ ] #4 All ../ links in docs/guides/BUILD.md and docs/guides/browser-debug-console.md resolve to real targets
+- [ ] #5 Cosmetic nits fixed: README.md:24 hard break, PIC_FIRMWARE_EN.md CH-water wording, FLASH_GUIDE_NL.md volgorde-eis
+- [ ] #6 Extended internal link checker reports 0 broken links across README + docs/{releases,api,features,guides,process}
+<!-- AC:END -->

--- a/backlog/tasks/task-605 - Fix-documentation-review-findings-1-5-on-dev.md
+++ b/backlog/tasks/task-605 - Fix-documentation-review-findings-1-5-on-dev.md
@@ -5,7 +5,7 @@ status: In Progress
 assignee:
   - '@claude'
 created_date: '2026-05-16 07:10'
-updated_date: '2026-05-16 07:10'
+updated_date: '2026-05-16 07:13'
 labels:
   - documentation
 dependencies: []
@@ -19,12 +19,12 @@ Address the 5 findings from the dev documentation review: README dev/stable bann
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 README.md banner correctly identifies dev as the development/1.5.x maintenance line (not 'stable/public release line')
-- [ ] #2 DOCUMENTATION_LINKS_POLICY.md rule 4 matches actual release-notes placement (v1.3.4 and older archived; v1.3.5/v1.4.1/v1.5.x current)
-- [ ] #3 .github/workflows/evaluate.yml link-check scope includes docs/guides and docs/process
-- [ ] #4 All ../ links in docs/guides/BUILD.md and docs/guides/browser-debug-console.md resolve to real targets
-- [ ] #5 Cosmetic nits fixed: README.md:24 hard break, PIC_FIRMWARE_EN.md CH-water wording, FLASH_GUIDE_NL.md volgorde-eis
-- [ ] #6 Extended internal link checker reports 0 broken links across README + docs/{releases,api,features,guides,process}
+- [x] #1 README.md banner correctly identifies dev as the development/1.5.x maintenance line (not 'stable/public release line')
+- [x] #2 DOCUMENTATION_LINKS_POLICY.md rule 4 matches actual release-notes placement (v1.3.4 and older archived; v1.3.5/v1.4.1/v1.5.x current)
+- [x] #3 .github/workflows/evaluate.yml link-check scope includes docs/guides and docs/process
+- [x] #4 All ../ links in docs/guides/BUILD.md and docs/guides/browser-debug-console.md resolve to real targets
+- [x] #5 Cosmetic nits fixed: README.md:24 hard break, PIC_FIRMWARE_EN.md CH-water wording, FLASH_GUIDE_NL.md volgorde-eis
+- [x] #6 Extended internal link checker reports 0 broken links across README + docs/{releases,api,features,guides,process}
 <!-- AC:END -->
 
 ## Implementation Plan
@@ -37,3 +37,18 @@ Address the 5 findings from the dev documentation review: README dev/stable bann
 5. F5 README hard break, PIC_FIRMWARE_EN CH wording, FLASH_GUIDE_NL volgorde-eis
 6. Run extended link checker -> 0 broken; commit+push; draft PR
 <!-- SECTION:PLAN:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Fixed all 5 dev documentation-review findings.
+
+Changes:
+- F1 README.md banner: replaced the main-oriented "stable/public release line" wording (self-contradictory on dev) with branch-correct text identifying dev as the 1.5.x maintenance line, pointing to main/v1.5.0 for stable.
+- F2 DOCUMENTATION_LINKS_POLICY.md rule 4: reworded so it matches actual placement (v1.3.4 and older archived; v1.3.5/v1.4.1/v1.5.x stay current) instead of the contradictory "v1.3.x and older".
+- F3 .github/workflows/evaluate.yml: added docs/guides and docs/process to the markdown link-check scope (previously the guardrail did not cover the files the recent doc cluster added).
+- F4 fixed broken relative links: docs/guides/BUILD.md (../ -> ../../ for README/Makefile/scripts) and docs/guides/browser-debug-console.md (../ -> ../../ for README anchors; .ino links repointed to real ../../src/OTGW-firmware/ paths).
+- F5 README.md:24 hard break (match line-31 trailing-space convention); PIC_FIRMWARE_EN.md "hot-water" -> "central-heating water" setpoint (matches NL aanvoerwatertemperatuur, removes DHW ambiguity); FLASH_GUIDE_NL.md "volgordekeuze" -> "volgorde-eis".
+
+Verification: extended internal link checker (README + docs/{releases,api,features,guides,process}) reports 0 broken links. Docs/CI-tooling only: no version bump, no ADR.
+<!-- SECTION:FINAL_SUMMARY:END -->

--- a/backlog/tasks/task-605 - Fix-documentation-review-findings-1-5-on-dev.md
+++ b/backlog/tasks/task-605 - Fix-documentation-review-findings-1-5-on-dev.md
@@ -1,9 +1,11 @@
 ---
 id: TASK-605
 title: Fix documentation review findings 1-5 on dev
-status: To Do
-assignee: []
+status: In Progress
+assignee:
+  - '@claude'
 created_date: '2026-05-16 07:10'
+updated_date: '2026-05-16 07:10'
 labels:
   - documentation
 dependencies: []
@@ -24,3 +26,14 @@ Address the 5 findings from the dev documentation review: README dev/stable bann
 - [ ] #5 Cosmetic nits fixed: README.md:24 hard break, PIC_FIRMWARE_EN.md CH-water wording, FLASH_GUIDE_NL.md volgorde-eis
 - [ ] #6 Extended internal link checker reports 0 broken links across README + docs/{releases,api,features,guides,process}
 <!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. F1 README.md:3-4 banner -> dev/maintenance wording
+2. F2 DOCUMENTATION_LINKS_POLICY.md:18 reword rule 4
+3. F4 fix ../ links in BUILD.md + browser-debug-console.md (verified targets)
+4. F3 add docs/guides+docs/process to evaluate.yml scope
+5. F5 README hard break, PIC_FIRMWARE_EN CH wording, FLASH_GUIDE_NL volgorde-eis
+6. Run extended link checker -> 0 broken; commit+push; draft PR
+<!-- SECTION:PLAN:END -->

--- a/backlog/tasks/task-605 - Fix-documentation-review-findings-1-5-on-dev.md
+++ b/backlog/tasks/task-605 - Fix-documentation-review-findings-1-5-on-dev.md
@@ -1,11 +1,11 @@
 ---
 id: TASK-605
 title: Fix documentation review findings 1-5 on dev
-status: In Progress
+status: Done
 assignee:
   - '@claude'
 created_date: '2026-05-16 07:10'
-updated_date: '2026-05-16 07:13'
+updated_date: '2026-05-16 07:20'
 labels:
   - documentation
 dependencies: []
@@ -41,14 +41,5 @@ Address the 5 findings from the dev documentation review: README dev/stable bann
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-Fixed all 5 dev documentation-review findings.
-
-Changes:
-- F1 README.md banner: replaced the main-oriented "stable/public release line" wording (self-contradictory on dev) with branch-correct text identifying dev as the 1.5.x maintenance line, pointing to main/v1.5.0 for stable.
-- F2 DOCUMENTATION_LINKS_POLICY.md rule 4: reworded so it matches actual placement (v1.3.4 and older archived; v1.3.5/v1.4.1/v1.5.x stay current) instead of the contradictory "v1.3.x and older".
-- F3 .github/workflows/evaluate.yml: added docs/guides and docs/process to the markdown link-check scope (previously the guardrail did not cover the files the recent doc cluster added).
-- F4 fixed broken relative links: docs/guides/BUILD.md (../ -> ../../ for README/Makefile/scripts) and docs/guides/browser-debug-console.md (../ -> ../../ for README anchors; .ino links repointed to real ../../src/OTGW-firmware/ paths).
-- F5 README.md:24 hard break (match line-31 trailing-space convention); PIC_FIRMWARE_EN.md "hot-water" -> "central-heating water" setpoint (matches NL aanvoerwatertemperatuur, removes DHW ambiguity); FLASH_GUIDE_NL.md "volgordekeuze" -> "volgorde-eis".
-
-Verification: extended internal link checker (README + docs/{releases,api,features,guides,process}) reports 0 broken links. Docs/CI-tooling only: no version bump, no ADR.
+CI note: PR #581 'Run evaluate.py --quick' is RED but PRE-EXISTING on dev base 97fd601 (verified: identical "4 unresolved ADR reference(s) out of 1224", Health 91.7%, before and after this commit; this commit changes zero ADR references). The markdown link-check step this PR governs passes (0 broken). Not a regression — out of scope for a docs review.
 <!-- SECTION:FINAL_SUMMARY:END -->

--- a/backlog/tasks/task-606 - feat-2.0.0-port-TASK-605-—-fix-broken-..-links-in-docs-guides.md
+++ b/backlog/tasks/task-606 - feat-2.0.0-port-TASK-605-—-fix-broken-..-links-in-docs-guides.md
@@ -1,11 +1,11 @@
 ---
 id: TASK-606
 title: 'feat-2.0.0: port TASK-605 — fix broken ../ links in docs/guides'
-status: In Progress
+status: Done
 assignee:
   - '@claude'
 created_date: '2026-05-16 07:10'
-updated_date: '2026-05-16 07:11'
+updated_date: '2026-05-16 07:20'
 labels:
   - documentation
 dependencies:
@@ -20,9 +20,9 @@ Port Finding 4 only from the dev documentation review to the 2.0.0 feature line.
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 All ../ links in 2.0.0 docs/guides/BUILD.md resolve to real targets (../../README.md, ../../Makefile, ../../scripts/autoinc-semver.py)
-- [ ] #2 All ../ links in 2.0.0 docs/guides/browser-debug-console.md resolve (../../README.md anchors; .ino links point at real src/OTGW-firmware/ paths)
-- [ ] #3 Link targets verified to exist on the 2.0.0 branch before editing (no assumed parity with dev)
+- [x] #1 All ../ links in 2.0.0 docs/guides/BUILD.md resolve to real targets (../../README.md, ../../Makefile, ../../scripts/autoinc-semver.py)
+- [x] #2 All ../ links in 2.0.0 docs/guides/browser-debug-console.md resolve (../../README.md anchors; .ino links point at real src/OTGW-firmware/ paths)
+- [x] #3 Link targets verified to exist on the 2.0.0 branch before editing (no assumed parity with dev)
 <!-- AC:END -->
 
 ## Implementation Plan
@@ -33,3 +33,15 @@ Port Finding 4 only from the dev documentation review to the 2.0.0 feature line.
 3. Fix ../ -> ../../ (and .ino -> ../../src/OTGW-firmware/)
 4. Run link checker on 2.0.0 guides -> 0 broken; commit+push; draft PR into 2.0.0
 <!-- SECTION:PLAN:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Ported dev review Finding 4 to the 2.0.0 line (docs-only).
+
+Fixed broken ../ relative links in docs/guides/BUILD.md and docs/guides/browser-debug-console.md (../ -> ../../; .ino links -> ../../src/OTGW-firmware/). Targets verified to exist on the 2.0.0 branch (no assumed parity). Findings 1/2/3/5 do not exist on 2.0.0 (different README, no policy doc/releases index, no link-check workflow block, no EN/NL guides).
+
+Landed via GitHub API (local commit signing is bound to the primary checkout and 400s in a linked worktree). Commit 509d3d7 on branch claude/review-documentation-2.0.0-8L1cy; draft PR #582 into feature-dev-2.0.0-otgw32-esp32-sat-support.
+
+CI note: #582 red checks (evaluate.py --quick, Spec-driven OT v4.2 audit, pio run -e esp8266) are PRE-EXISTING on the 2.0.0 alpha base 201b301b (verified: base evaluate.py --quick already Failed:1, Health 95.6%). A 14-line markdown link change cannot affect firmware compilation or the OT spec audit — not regressions from this task.
+<!-- SECTION:FINAL_SUMMARY:END -->

--- a/backlog/tasks/task-606 - feat-2.0.0-port-TASK-605-—-fix-broken-..-links-in-docs-guides.md
+++ b/backlog/tasks/task-606 - feat-2.0.0-port-TASK-605-—-fix-broken-..-links-in-docs-guides.md
@@ -1,0 +1,23 @@
+---
+id: TASK-606
+title: 'feat-2.0.0: port TASK-605 — fix broken ../ links in docs/guides'
+status: To Do
+assignee: []
+created_date: '2026-05-16 07:10'
+labels:
+  - documentation
+dependencies: []
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Port Finding 4 only from the dev documentation review to the 2.0.0 feature line. Findings 1,2,3,5 do not apply on 2.0.0 (no dev/stable README banner, no DOCUMENTATION_LINKS_POLICY.md, no docs/releases/README.md, no link-check workflow block, no EN/NL guide split). Only the broken relative links in docs/guides/BUILD.md and docs/guides/browser-debug-console.md exist there.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 All ../ links in 2.0.0 docs/guides/BUILD.md resolve to real targets (../../README.md, ../../Makefile, ../../scripts/autoinc-semver.py)
+- [ ] #2 All ../ links in 2.0.0 docs/guides/browser-debug-console.md resolve (../../README.md anchors; .ino links point at real src/OTGW-firmware/ paths)
+- [ ] #3 Link targets verified to exist on the 2.0.0 branch before editing (no assumed parity with dev)
+<!-- AC:END -->

--- a/backlog/tasks/task-606 - feat-2.0.0-port-TASK-605-—-fix-broken-..-links-in-docs-guides.md
+++ b/backlog/tasks/task-606 - feat-2.0.0-port-TASK-605-—-fix-broken-..-links-in-docs-guides.md
@@ -1,12 +1,15 @@
 ---
 id: TASK-606
 title: 'feat-2.0.0: port TASK-605 — fix broken ../ links in docs/guides'
-status: To Do
-assignee: []
+status: In Progress
+assignee:
+  - '@claude'
 created_date: '2026-05-16 07:10'
+updated_date: '2026-05-16 07:11'
 labels:
   - documentation
-dependencies: []
+dependencies:
+  - TASK-605
 ---
 
 ## Description
@@ -21,3 +24,12 @@ Port Finding 4 only from the dev documentation review to the 2.0.0 feature line.
 - [ ] #2 All ../ links in 2.0.0 docs/guides/browser-debug-console.md resolve (../../README.md anchors; .ino links point at real src/OTGW-firmware/ paths)
 - [ ] #3 Link targets verified to exist on the 2.0.0 branch before editing (no assumed parity with dev)
 <!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Add worktree off origin/feature-dev-2.0.0-...
+2. Verify exact lines/targets in 2.0.0 BUILD.md + browser-debug-console.md
+3. Fix ../ -> ../../ (and .ino -> ../../src/OTGW-firmware/)
+4. Run link checker on 2.0.0 guides -> 0 broken; commit+push; draft PR into 2.0.0
+<!-- SECTION:PLAN:END -->

--- a/docs/guides/BUILD.md
+++ b/docs/guides/BUILD.md
@@ -322,10 +322,10 @@ The GitHub Actions workflow (`.github/workflows/main.yml`) uses the same Makefil
 
 ## Further Reading
 
-- **Main README**: [../README.md](../README.md)
+- **Main README**: [../../README.md](../../README.md)
 - **Wiki**: <https://github.com/rvdbreemen/OTGW-firmware/wiki>
-- **Makefile reference**: [../Makefile](../Makefile)
-- **Version script**: [../scripts/autoinc-semver.py](../scripts/autoinc-semver.py)
+- **Makefile reference**: [../../Makefile](../../Makefile)
+- **Version script**: [../../scripts/autoinc-semver.py](../../scripts/autoinc-semver.py)
 
 ## Getting Help
 

--- a/docs/guides/FLASH_GUIDE_NL.md
+++ b/docs/guides/FLASH_GUIDE_NL.md
@@ -270,7 +270,7 @@ Importeer na het flashen je instellingen opnieuw via de webinterface.
 4. Vernieuw de browser hard (Ctrl+F5)
 5. Importeer je instellingen opnieuw
 
-**Deze volgordekeuze geldt NIET voor v1.4.x → v1.5.x upgrades** (de partitie-indeling
+**Deze volgorde-eis geldt NIET voor v1.4.x → v1.5.x upgrades** (de partitie-indeling
 is identiek).
 
 ---

--- a/docs/guides/PIC_FIRMWARE_EN.md
+++ b/docs/guides/PIC_FIRMWARE_EN.md
@@ -24,7 +24,7 @@ boiler. It is the only part of the device that can speak the OpenTherm protocol:
 
 - It reads every message your thermostat sends to the boiler, and every reply from the boiler.
 - It lets the gateway *intercept* those messages so it can, for example, raise or lower the
-  boiler's hot-water temperature setpoint independently of what the thermostat asked for.
+  boiler's central-heating water temperature setpoint independently of what the thermostat asked for.
 - It sends commands to the boiler on behalf of the gateway when you request an override.
 
 Without a working PIC firmware:

--- a/docs/guides/browser-debug-console.md
+++ b/docs/guides/browser-debug-console.md
@@ -455,10 +455,10 @@ console.log('Flash mode:', flashModeActive)
 
 ## See Also
 
-- [Telnet Debug Interface](../handleDebug.ino) - Server-side debug menu
-- [REST API Documentation](../README.md#rest-api) - API endpoint reference
-- [MQTT Commands](../README.md#mqtt) - MQTT command reference
-- [WebSocket Implementation](../webSocketStuff.ino) - WebSocket source code
+- [Telnet Debug Interface](../../src/OTGW-firmware/handleDebug.ino) - Server-side debug menu
+- [REST API Documentation](../../README.md#rest-api) - API endpoint reference
+- [MQTT Commands](../../README.md#mqtt) - MQTT command reference
+- [WebSocket Implementation](../../src/OTGW-firmware/webSocketStuff.ino) - WebSocket source code
 
 ---
 

--- a/docs/process/DOCUMENTATION_LINKS_POLICY.md
+++ b/docs/process/DOCUMENTATION_LINKS_POLICY.md
@@ -15,5 +15,5 @@ Use these canonical locations when adding or updating documentation links:
 1. Prefer links to canonical files, not legacy paths kept for historical context.
 2. In repository-root files (for example `README.md`), use root-relative paths like `docs/guides/FLASH_GUIDE.md`.
 3. In nested docs, use correct relative paths from the current file location (`../` or `../../` as needed).
-4. Link to `docs/releases/archive/` intentionally for historical versions (`v1.3.x` and older).
+4. Link to `docs/releases/archive/` intentionally for archived historical versions (`v1.3.4` and older); `v1.3.5`, `v1.4.1`, and `v1.5.x` notes stay current in `docs/releases/`.
 5. Keep release navigation up to date in `docs/releases/README.md` when adding or moving release notes.


### PR DESCRIPTION
## Summary

Fixes the 5 findings from a review of the recent documentation cluster on `dev` (PRs #573/#574/#578/#579/#580). Docs + CI-tooling only — no firmware change, no version bump, no ADR.

- **F1** `README.md` banner — replaced the main-oriented "stable/public release line" wording (self-contradictory on `dev`: it told `dev` readers `dev` was stable and pointed them back to `dev`) with branch-correct text identifying `dev` as the 1.5.x maintenance line, pointing to `main`/v1.5.0 for stable.
- **F2** `docs/process/DOCUMENTATION_LINKS_POLICY.md` rule 4 — reworded to match actual placement (`v1.3.4` and older archived; `v1.3.5`/`v1.4.1`/`v1.5.x` stay current), resolving the contradiction with `docs/releases/README.md`.
- **F3** `.github/workflows/evaluate.yml` — added `docs/guides` + `docs/process` to the markdown link-check scope; the guardrail added in #573 did not cover the files added by #578/#579/#580.
- **F4** fixed broken relative links in `docs/guides/BUILD.md` and `docs/guides/browser-debug-console.md` (`../` → `../../`; `.ino` links repointed to real `../../src/OTGW-firmware/` paths) — pre-existing breakage from the TASK-577 move, now caught by the extended F3 scope.
- **F5** `README.md:24` hard break (matches line-31 convention); `PIC_FIRMWARE_EN.md` "hot-water" → "central-heating water" setpoint (matches NL `aanvoerwatertemperatuur`, removes DHW ambiguity); `FLASH_GUIDE_NL.md` "volgordekeuze" → "volgorde-eis".

A sibling change ports **F4 only** to the 2.0.0 branch (separate PR/task TASK-606); F1/F2/F3/F5 do not exist on 2.0.0 (different README, no policy doc, no releases index, no link-check block, no EN/NL guides).

## Test plan

- [x] Extended internal link checker (README + `docs/{releases,api,features,guides,process}`) reports 0 broken links
- [ ] Maintainer confirms the `dev` banner wording is acceptable

Backlog: TASK-605

https://claude.ai/code/session_01F6KdWyuSWXxnVED3rkMfqw

---
_Generated by [Claude Code](https://claude.ai/code/session_01F6KdWyuSWXxnVED3rkMfqw)_