### PR TITLE
docs(2.0.0): fix broken ../ relative links in docs/guides

### DIFF
--- a/docs/guides/BUILD.md
+++ b/docs/guides/BUILD.md
@@ -320,10 +320,10 @@ The GitHub Actions workflow (`.github/workflows/main.yml`) uses the same Makefil
 
 ## Further Reading
 
-- **Main README**: [../README.md](../README.md)
+- **Main README**: [../../README.md](../../README.md)
 - **Wiki**: <https://github.com/rvdbreemen/OTGW-firmware/wiki>
-- **Makefile reference**: [../Makefile](../Makefile)
-- **Version script**: [../scripts/autoinc-semver.py](../scripts/autoinc-semver.py)
+- **Makefile reference**: [../../Makefile](../../Makefile)
+- **Version script**: [../../scripts/autoinc-semver.py](../../scripts/autoinc-semver.py)
 
 ## Getting Help
 

--- a/docs/guides/browser-debug-console.md
+++ b/docs/guides/browser-debug-console.md
@@ -455,10 +455,10 @@ console.log('Flash mode:', flashModeActive)
 
 ## See Also
 
-- [Telnet Debug Interface](../handleDebug.ino) - Server-side debug menu
-- [REST API Documentation](../README.md#rest-api) - API endpoint reference
-- [MQTT Commands](../README.md#mqtt) - MQTT command reference
-- [WebSocket Implementation](../webSocketStuff.ino) - WebSocket source code
+- [Telnet Debug Interface](../../src/OTGW-firmware/handleDebug.ino) - Server-side debug menu
+- [REST API Documentation](../../README.md#rest-api) - API endpoint reference
+- [MQTT Commands](../../README.md#mqtt) - MQTT command reference
+- [WebSocket Implementation](../../src/OTGW-firmware/webSocketStuff.ino) - WebSocket source code
 
 ---
 


### PR DESCRIPTION
## Summary

Ports **Finding 4 only** from the dev documentation review to the 2.0.0 feature line. Docs-only; no firmware change.

`docs/guides/BUILD.md` and `docs/guides/browser-debug-console.md` used `../` relative links that resolve one directory short (the files were moved into `docs/guides/` without updating link depth). Fixed:

- `../README.md` → `../../README.md`, `../Makefile` → `../../Makefile`, `../scripts/autoinc-semver.py` → `../../scripts/autoinc-semver.py`
- `../handleDebug.ino` → `../../src/OTGW-firmware/handleDebug.ino`, `../webSocketStuff.ino` → `../../src/OTGW-firmware/webSocketStuff.ino` (verified real source locations on this branch)
- `../README.md#rest-api` / `#mqtt` → `../../README.md#…`

Findings 1/2/3/5 from the dev review do **not** apply here: the 2.0.0 README has no dev/stable banner, there is no `DOCUMENTATION_LINKS_POLICY.md` / `docs/releases/README.md`, the 2.0.0 `evaluate.yml` has no link-check block, and there is no EN/NL guide split. Verified against this branch's sources (no assumed parity with dev).

Sibling PR on dev: #581. Backlog: TASK-606 (depends on TASK-605).

## Test plan

- [x] Internal link checker over `docs/guides/` on this branch reports 0 broken links

https://claude.ai/code/session_01F6KdWyuSWXxnVED3rkMfqw

---
_Generated by [Claude Code](https://claude.ai/code/session_01F6KdWyuSWXxnVED3rkMfqw)_