### PR TITLE
chore(backlog): track CI baseline follow-up tasks (TASK-608, TASK-609)

### DIFF
--- a/backlog/tasks/task-608 - Resolve-4-unresolved-ADR-references-flagged-by-evaluate.py-quick-dev-baseline.md
+++ b/backlog/tasks/task-608 - Resolve-4-unresolved-ADR-references-flagged-by-evaluate.py-quick-dev-baseline.md
@@ -1,0 +1,27 @@
+---
+id: TASK-608
+title: >-
+  Resolve 4 unresolved ADR references flagged by evaluate.py --quick (dev
+  baseline)
+status: To Do
+assignee: []
+created_date: '2026-05-16 07:26'
+labels:
+  - ci
+  - tech-debt
+dependencies: []
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+evaluate.py --quick fails the [ADR] References resolve check with '4 unresolved ADR reference(s) out of 1224' on the dev baseline (verified at commit 97fd601: Failed:1, Health 91.7%, identical before/after docs PR #581). Pre-existing baseline failure surfaced during the documentation review; it keeps every dev PR's 'Run evaluate.py --quick' check red and masks genuinely new evaluate.py failures. Identify the 4 dangling ADR references and resolve each (fix the citing reference, restore/add the missing ADR, or correct a supersession note).
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 The 4 unresolved ADR references are enumerated with citing file:line and the ADR-NNN each points at
+- [ ] #2 Each reference is resolved (corrected citation, added/restored ADR, or fixed supersession link) with rationale recorded
+- [ ] #3 python evaluate.py --quick reports the [ADR] References resolve check as passing (0 unresolved out of total)
+- [ ] #4 python evaluate.py --quick shows no new failures vs the documented baseline (Health Score improves; Failed count for this check is 0)
+<!-- AC:END -->

--- a/backlog/tasks/task-609 - feat-2.0.0-triage-pre-existing-CI-baseline-failures-on-the-alpha-branch.md
+++ b/backlog/tasks/task-609 - feat-2.0.0-triage-pre-existing-CI-baseline-failures-on-the-alpha-branch.md
@@ -1,0 +1,25 @@
+---
+id: TASK-609
+title: 'feat-2.0.0: triage pre-existing CI baseline failures on the alpha branch'
+status: To Do
+assignee: []
+created_date: '2026-05-16 07:26'
+labels:
+  - ci
+  - tech-debt
+  - 2.0.0
+dependencies: []
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+The 2.0.0 feature line (feature-dev-2.0.0-otgw32-esp32-sat-support, base 201b301b / alpha.34) has multiple red CI checks at baseline, surfaced by docs-only PR #582: 'Run evaluate.py --quick' (verified base Failed:1, Health 95.6%), 'Spec-driven OT v4.2 audit', 'pio run -e esp8266', and 'pio run -e esp32'. None are caused by documentation changes (a 14-line markdown link fix cannot affect firmware compilation or the OT spec audit). These baseline reds prevent CI-green merges on the 2.0.0 line and mask real regressions. Triage each, classify pre-existing-vs-in-progress, and fix or file scoped follow-ups. Work happens in the 2.0.0 worktree.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Each failing 2.0.0 check (evaluate.py --quick, Spec-driven OT v4.2 audit, pio run -e esp8266, pio run -e esp32) is triaged with documented root cause
+- [ ] #2 Each is either fixed, or has a tracked follow-up with explicit rationale if intentionally deferred for alpha
+- [ ] #3 A clean docs-only PR against the 2.0.0 branch shows no baseline reds, OR remaining reds are explicitly accepted-for-alpha and documented in the task
+<!-- AC:END -->


### PR DESCRIPTION
## Summary

Backlog-only. Adds two follow-up tasks for the **pre-existing CI baseline failures** surfaced (but out of scope) during the documentation review (#581 / #582). No code or doc changes.

- **TASK-608** (dev) — Resolve the 4 unresolved ADR references flagged by `evaluate.py --quick`. Verified pre-existing on dev base `97fd601` (Failed:1, Health 91.7%); keeps every dev PR's `evaluate.py --quick` check red and masks genuinely new failures.
- **TASK-609** (2.0.0) — Triage the pre-existing CI baseline reds on the `feature-dev-2.0.0-...sat-support` alpha branch (`evaluate.py --quick`, `Spec-driven OT v4.2 audit`, `pio run -e esp8266`, `pio run -e esp32`). None caused by docs; verified base `201b301b` already red.

Both are `To Do` (future work, not started).

## Test plan

- [x] `backlog task list` shows TASK-608 and TASK-609 as To Do
- [x] PR diff is exactly the two `backlog/tasks/task-608*.md` / `task-609*.md` files

https://claude.ai/code/session_01F6KdWyuSWXxnVED3rkMfqw

---
_Generated by [Claude Code](https://claude.ai/code/session_01F6KdWyuSWXxnVED3rkMfqw)_