### PR TITLE
feat(tooling): standalone HA discovery topic wiper (TASK-611)

### DIFF
--- a/backlog/tasks/task-611 - Standalone-HA-discovery-wipe-script.md
+++ b/backlog/tasks/task-611 - Standalone-HA-discovery-wipe-script.md
@@ -5,7 +5,7 @@ status: In Progress
 assignee:
   - '@claude'
 created_date: '2026-05-16 08:59'
-updated_date: '2026-05-16 08:59'
+updated_date: '2026-05-16 09:10'
 labels:
   - tooling
 dependencies: []
@@ -19,11 +19,11 @@ Provide a standalone Python utility that clears retained Home Assistant MQTT dis
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Script is standalone (stdlib-only, no pip install required) and runnable directly with python3
-- [ ] #2 Device unique_id and ha_prefix are discovered via the OTGW REST API; hostname defaults to OTGW.local and can be overridden
-- [ ] #3 Only retained discovery '/config' topics scoped to the resolved device unique_id are targeted; other devices on a shared broker are never touched
-- [ ] #4 User must explicitly authorize the wipe via an interactive confirmation dialog before any topic is cleared; a dry-run mode lists topics without wiping
-- [ ] #5 Retained discovery topics are cleared by publishing zero-length retained payloads; script reports the count wiped
+- [x] #1 Script is standalone (stdlib-only, no pip install required) and runnable directly with python3
+- [x] #2 Device unique_id and ha_prefix are discovered via the OTGW REST API; hostname defaults to OTGW.local and can be overridden
+- [x] #3 Only retained discovery '/config' topics scoped to the resolved device unique_id are targeted; other devices on a shared broker are never touched
+- [x] #4 User must explicitly authorize the wipe via an interactive confirmation dialog before any topic is cleared; a dry-run mode lists topics without wiping
+- [x] #5 Retained discovery topics are cleared by publishing zero-length retained payloads; script reports the count wiped
 <!-- AC:END -->
 
 ## Implementation Plan
@@ -37,3 +37,27 @@ Provide a standalone Python utility that clears retained Home Assistant MQTT dis
 6. Wipe: publish zero-length retained payload per matched topic; report count.
 7. Place at scripts/wipe_ha_discovery.py; manual smoke (argparse --help, dry-run path).
 <!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Implemented scripts/wipe_ha_discovery.py (stdlib-only MQTT 3.1.1 subset). REST discovery tries /api/v2/debug then /api/v2/settings (HTTP basic auth optional) then /api/v2/device/info (unauth, derives default otgw-<MAC> unique_id). Topic scoping: last segment == config AND ha_prefix head AND unique_id is a path segment. Confirmation requires typing WIPE; --dry-run and --yes supported. Added auto-installing wrappers wipe_ha_discovery.sh / .bat per user request. Verified end-to-end with an in-process MQTT broker stub: only the target device config topics cleared (other device excluded), clears use retain=1 + empty payload; dry-run and confirm-decline publish nothing.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Add a standalone, dependency-free utility to wipe an OTGW's retained Home Assistant MQTT discovery topics.
+
+What & why: After removing/renaming an OTGW, stale retained <ha_prefix>/<component>/<unique_id>/.../config topics keep ghost entities alive in Home Assistant. This script clears exactly those, scoped to one device.
+
+Changes:
+- scripts/wipe_ha_discovery.py: stdlib-only (no pip). Discovers unique_id/ha_prefix/broker/port/mqtt_user via OTGW REST (/api/v2/debug -> /api/v2/settings -> /api/v2/device/info; host defaults to OTGW.local, all values overridable by CLI). Minimal MQTT 3.1.1 client (CONNECT/SUBSCRIBE/PUBLISH/DISCONNECT). Collects retained topics, matches only last-segment "config" topics that contain the resolved unique_id, requires an interactive "WIPE" confirmation (or --yes), supports --dry-run, then clears each topic with a zero-length retained publish and reports the count.
+- scripts/wipe_ha_discovery.sh / .bat: launchers that locate Python 3 and auto-install it (apt/dnf/yum/pacman/zypper/apk/brew; winget/choco on Windows) when absent, with WIPE_HA_NO_AUTOINSTALL=1 opt-out and manual-install fallback messaging.
+
+User impact: other devices on a shared broker are never touched; nothing is changed without explicit confirmation.
+
+Tests: py_compile + sh -n syntax; argparse --help; end-to-end against an in-process MQTT broker stub proving (a) only the target device's config topics are cleared, (b) clears use retain flag + empty payload, (c) --dry-run and a declined confirmation publish nothing.
+
+Risks/follow-ups: .local resolution depends on host mDNS (script prints guidance and accepts --host <ip>); broker host/MQTT user are only auto-discovered when the OTGW debug/settings endpoint is reachable (HTTP password supplied if set) - otherwise pass --broker. Tooling-only change (scripts/**): exempt from version bump and firmware build/evaluator gates per project policy.
+<!-- SECTION:FINAL_SUMMARY:END -->

--- a/backlog/tasks/task-611 - Standalone-HA-discovery-wipe-script.md
+++ b/backlog/tasks/task-611 - Standalone-HA-discovery-wipe-script.md
@@ -1,0 +1,25 @@
+---
+id: TASK-611
+title: Standalone HA discovery wipe script
+status: To Do
+assignee: []
+created_date: '2026-05-16 08:59'
+labels:
+  - tooling
+dependencies: []
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Provide a standalone Python utility that clears retained Home Assistant MQTT discovery (config) topics for a specific OTGW device. The script discovers the device unique_id / ha_prefix via the OTGW REST API (defaulting to OTGW.local), connects to the MQTT broker, and wipes only this device's retained discovery config topics after explicit user confirmation.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Script is standalone (stdlib-only, no pip install required) and runnable directly with python3
+- [ ] #2 Device unique_id and ha_prefix are discovered via the OTGW REST API; hostname defaults to OTGW.local and can be overridden
+- [ ] #3 Only retained discovery '/config' topics scoped to the resolved device unique_id are targeted; other devices on a shared broker are never touched
+- [ ] #4 User must explicitly authorize the wipe via an interactive confirmation dialog before any topic is cleared; a dry-run mode lists topics without wiping
+- [ ] #5 Retained discovery topics are cleared by publishing zero-length retained payloads; script reports the count wiped
+<!-- AC:END -->

--- a/backlog/tasks/task-611 - Standalone-HA-discovery-wipe-script.md
+++ b/backlog/tasks/task-611 - Standalone-HA-discovery-wipe-script.md
@@ -1,7 +1,7 @@
 ---
 id: TASK-611
 title: Standalone HA discovery wipe script
-status: In Progress
+status: Done
 assignee:
   - '@claude'
 created_date: '2026-05-16 08:59'

--- a/backlog/tasks/task-611 - Standalone-HA-discovery-wipe-script.md
+++ b/backlog/tasks/task-611 - Standalone-HA-discovery-wipe-script.md
@@ -1,9 +1,11 @@
 ---
 id: TASK-611
 title: Standalone HA discovery wipe script
-status: To Do
-assignee: []
+status: In Progress
+assignee:
+  - '@claude'
 created_date: '2026-05-16 08:59'
+updated_date: '2026-05-16 08:59'
 labels:
   - tooling
 dependencies: []
@@ -23,3 +25,15 @@ Provide a standalone Python utility that clears retained Home Assistant MQTT dis
 - [ ] #4 User must explicitly authorize the wipe via an interactive confirmation dialog before any topic is cleared; a dry-run mode lists topics without wiping
 - [ ] #5 Retained discovery topics are cleared by publishing zero-length retained payloads; script reports the count wiped
 <!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Probe OTGW REST API: GET /api/v2/device/info (no auth) for hostname+macaddress; try /api/v2/settings & /api/v2/debug (HTTP basic auth if creds given) for exact mqttuniqueid/mqtthaprefix/broker/port/user.
+2. Resolve device id: use settings.mqtt.unique_id when available, else derive default otgw-<MAC w/o colons, upper>; ha_prefix default homeassistant.
+3. Zero-dependency MQTT 3.1.1 client (stdlib socket): CONNECT (opt user/pass), SUBSCRIBE <prefix>/#, collect retained PUBLISHes until idle timeout.
+4. Filter topics: last segment == config AND resolved unique_id is a path segment (scoped to this device only).
+5. Confirmation dialog: list matched topics, require explicit typed yes; --dry-run lists only; --yes bypass for automation.
+6. Wipe: publish zero-length retained payload per matched topic; report count.
+7. Place at scripts/wipe_ha_discovery.py; manual smoke (argparse --help, dry-run path).
+<!-- SECTION:PLAN:END -->

--- a/scripts/wipe_ha_discovery.bat
+++ b/scripts/wipe_ha_discovery.bat
@@ -1,0 +1,68 @@
+@echo off
+rem Launcher for wipe_ha_discovery.py (Windows).
+rem Finds a Python 3 interpreter and, if none is present, attempts to install
+rem one with winget or Chocolatey before running the wiper.
+rem Set WIPE_HA_NO_AUTOINSTALL=1 to disable the auto-install step.
+setlocal EnableExtensions
+
+set "SCRIPT_DIR=%~dp0"
+set "PY_SCRIPT=%SCRIPT_DIR%wipe_ha_discovery.py"
+set "PY="
+
+call :find_python
+if defined PY goto run
+
+if "%WIPE_HA_NO_AUTOINSTALL%"=="1" (
+    echo Python 3 not found and auto-install disabled.>&2
+    echo Install Python 3 from https://www.python.org/downloads/ and re-run.>&2
+    exit /b 1
+)
+
+echo Python 3 not found. Attempting to install it ...
+where winget >nul 2>&1
+if %ERRORLEVEL%==0 (
+    echo Installing Python 3 via winget ...
+    winget install -e --id Python.Python.3.12 --silent --accept-package-agreements --accept-source-agreements
+    goto recheck
+)
+where choco >nul 2>&1
+if %ERRORLEVEL%==0 (
+    echo Installing Python 3 via Chocolatey ...
+    choco install -y python
+    goto recheck
+)
+echo Could not auto-install Python 3 ^(winget/choco not found^).>&2
+echo Install it manually from https://www.python.org/downloads/ and re-run.>&2
+exit /b 1
+
+:recheck
+call :find_python
+if defined PY (
+    echo Python 3 installed successfully.
+    goto run
+)
+echo Python was installed but is not on PATH yet.>&2
+echo Close and reopen this terminal, then run this script again.>&2
+exit /b 1
+
+:run
+"%PY%" %PY_LAUNCH_ARG% "%PY_SCRIPT%" %*
+exit /b %ERRORLEVEL%
+
+:find_python
+rem Prefer the py launcher (py -3), then python / python3 on PATH.
+py -3 -c "import sys; raise SystemExit(0 if sys.version_info[0]==3 else 1)" >nul 2>&1
+if %ERRORLEVEL%==0 (
+    set "PY=py"
+    set "PY_LAUNCH_ARG=-3"
+    exit /b 0
+)
+for %%C in (python python3) do (
+    %%C -c "import sys; raise SystemExit(0 if sys.version_info[0]==3 else 1)" >nul 2>&1
+    if not errorlevel 1 (
+        set "PY=%%C"
+        set "PY_LAUNCH_ARG="
+        exit /b 0
+    )
+)
+exit /b 1

--- a/scripts/wipe_ha_discovery.py
+++ b/scripts/wipe_ha_discovery.py
@@ -1,0 +1,480 @@
+#!/usr/bin/env python3
+"""Standalone wiper for OTGW Home Assistant MQTT discovery (config) topics.
+
+Clears the *retained* Home Assistant discovery topics that an OTGW publishes
+(`<ha_prefix>/<component>/<unique_id>/.../config`). Home Assistant removes the
+matching entities once the retained config payloads are gone.
+
+The device identity (unique_id / ha_prefix) and the broker address are
+discovered automatically through the OTGW REST API (default host
+``OTGW.local``). CLI flags override every discovered value.
+
+Stdlib only - no pip install required. The MQTT 3.1.1 client below speaks just
+the subset needed: CONNECT / SUBSCRIBE / PUBLISH / DISCONNECT.
+
+Scope safety: only retained topics whose path ends in ``config`` AND that
+contain the resolved unique_id as a path segment are touched, so other devices
+sharing the broker are never affected.
+"""
+
+import argparse
+import base64
+import getpass
+import json
+import os
+import socket
+import struct
+import sys
+import urllib.error
+import urllib.request
+
+DEFAULT_HOST = "OTGW.local"
+DEFAULT_HA_PREFIX = "homeassistant"
+DEFAULT_MQTT_PORT = 1883
+
+
+# --------------------------------------------------------------------------
+# REST discovery
+# --------------------------------------------------------------------------
+def _http_get_json(url, http_user, http_pass, timeout):
+    req = urllib.request.Request(url)
+    if http_pass:
+        token = base64.b64encode(
+            f"{http_user}:{http_pass}".encode("utf-8")
+        ).decode("ascii")
+        req.add_header("Authorization", f"Basic {token}")
+    with urllib.request.urlopen(req, timeout=timeout) as resp:
+        raw = resp.read().decode("utf-8", "replace")
+    return json.loads(raw)
+
+
+def discover_from_rest(host, http_user, http_pass, timeout):
+    """Return a dict with any of unique_id/ha_prefix/broker/port/mqtt_user
+    that could be read from the OTGW REST API. Best effort - missing keys are
+    simply absent from the returned dict."""
+    base = f"http://{host}"
+    found = {}
+
+    # /api/v2/debug - flat keys, has everything (auth-protected only if an
+    # HTTP password is configured on the OTGW).
+    try:
+        dbg = _http_get_json(
+            f"{base}/api/v2/debug", http_user, http_pass, timeout
+        ).get("debug", {})
+        if dbg.get("settings.mqtt.unique_id"):
+            found["unique_id"] = str(dbg["settings.mqtt.unique_id"])
+        if dbg.get("settings.mqtt.ha_prefix"):
+            found["ha_prefix"] = str(dbg["settings.mqtt.ha_prefix"])
+        if dbg.get("settings.mqtt.broker"):
+            found["broker"] = str(dbg["settings.mqtt.broker"])
+        if dbg.get("settings.mqtt.port"):
+            found["port"] = int(dbg["settings.mqtt.port"])
+        if dbg.get("settings.mqtt.user"):
+            found["mqtt_user"] = str(dbg["settings.mqtt.user"])
+    except (urllib.error.URLError, ValueError, OSError, KeyError):
+        pass
+
+    # /api/v2/settings - nested {"value": ...} form, same auth rules.
+    if not {"unique_id", "ha_prefix", "broker"} <= found.keys():
+        try:
+            st = _http_get_json(
+                f"{base}/api/v2/settings", http_user, http_pass, timeout
+            ).get("settings", {})
+
+            def sval(key):
+                v = st.get(key)
+                return v.get("value") if isinstance(v, dict) else None
+
+            if "unique_id" not in found and sval("mqttuniqueid"):
+                found["unique_id"] = str(sval("mqttuniqueid"))
+            if "ha_prefix" not in found and sval("mqtthaprefix"):
+                found["ha_prefix"] = str(sval("mqtthaprefix"))
+            if "broker" not in found and sval("mqttbroker"):
+                found["broker"] = str(sval("mqttbroker"))
+            if "port" not in found and sval("mqttbrokerport") is not None:
+                found["port"] = int(sval("mqttbrokerport"))
+            if "mqtt_user" not in found and sval("mqttuser"):
+                found["mqtt_user"] = str(sval("mqttuser"))
+        except (urllib.error.URLError, ValueError, OSError, KeyError):
+            pass
+
+    # /api/v2/device/info - never auth-protected. Gives hostname + MAC so we
+    # can reconstruct the firmware's default unique_id (otgw-<MAC>).
+    try:
+        dev = _http_get_json(
+            f"{base}/api/v2/device/info", http_user, http_pass, timeout
+        ).get("device", {})
+        if dev.get("hostname"):
+            found["hostname"] = str(dev["hostname"])
+        if "unique_id" not in found and dev.get("macaddress"):
+            mac = str(dev["macaddress"]).replace(":", "").upper()
+            if mac:
+                found["unique_id"] = f"otgw-{mac}"
+                found["unique_id_is_default"] = True
+    except (urllib.error.URLError, ValueError, OSError, KeyError):
+        pass
+
+    return found
+
+
+# --------------------------------------------------------------------------
+# Minimal MQTT 3.1.1 client (stdlib sockets only)
+# --------------------------------------------------------------------------
+class MqttError(Exception):
+    pass
+
+
+def _enc_str(s):
+    b = s.encode("utf-8")
+    return struct.pack("!H", len(b)) + b
+
+
+def _enc_remaining_length(n):
+    out = bytearray()
+    while True:
+        digit = n & 0x7F
+        n >>= 7
+        if n:
+            digit |= 0x80
+        out.append(digit)
+        if not n:
+            break
+    return bytes(out)
+
+
+class MiniMQTT:
+    def __init__(self, host, port, timeout):
+        self._timeout = timeout
+        self._sock = socket.create_connection((host, port), timeout=timeout)
+        self._buf = b""
+
+    def _send(self, data):
+        self._sock.sendall(data)
+
+    def _recv_exact(self, n):
+        while len(self._buf) < n:
+            chunk = self._sock.recv(4096)
+            if not chunk:
+                raise MqttError("broker closed the connection")
+            self._buf += chunk
+        out, self._buf = self._buf[:n], self._buf[n:]
+        return out
+
+    def _recv_remaining_length(self):
+        mult = 1
+        value = 0
+        while True:
+            (byte,) = struct.unpack("!B", self._recv_exact(1))
+            value += (byte & 0x7F) * mult
+            if not (byte & 0x80):
+                return value
+            mult *= 128
+            if mult > 128 ** 3:
+                raise MqttError("malformed remaining length")
+
+    def connect(self, client_id, username=None, password=None, keepalive=60):
+        flags = 0x02  # clean session
+        payload = _enc_str(client_id)
+        if username:
+            flags |= 0x80
+            payload += _enc_str(username)
+            if password is not None:
+                flags |= 0x40
+                pw = password.encode("utf-8")
+                payload += struct.pack("!H", len(pw)) + pw
+        var_header = _enc_str("MQTT") + struct.pack("!BBH", 0x04, flags, keepalive)
+        body = var_header + payload
+        self._send(b"\x10" + _enc_remaining_length(len(body)) + body)
+
+        (b1,) = struct.unpack("!B", self._recv_exact(1))
+        if b1 != 0x20:
+            raise MqttError(f"expected CONNACK, got control byte 0x{b1:02x}")
+        rem = self._recv_remaining_length()
+        ack = self._recv_exact(rem)
+        if len(ack) < 2 or ack[1] != 0x00:
+            code = ack[1] if len(ack) >= 2 else -1
+            raise MqttError(f"broker refused connection (CONNACK code {code})")
+
+    def subscribe(self, topic_filter, qos=0):
+        pkt_id = 1
+        body = struct.pack("!H", pkt_id) + _enc_str(topic_filter) + bytes([qos])
+        self._send(b"\x82" + _enc_remaining_length(len(body)) + body)
+        (b1,) = struct.unpack("!B", self._recv_exact(1))
+        if b1 != 0x90:
+            raise MqttError(f"expected SUBACK, got control byte 0x{b1:02x}")
+        rem = self._recv_remaining_length()
+        ack = self._recv_exact(rem)
+        if ack and ack[-1] == 0x80:
+            raise MqttError("broker rejected the subscription")
+
+    def collect_retained(self, idle_timeout):
+        """Return {topic: payload_bytes} for every retained message the broker
+        delivers. Stops after idle_timeout seconds without a new packet."""
+        retained = {}
+        self._sock.settimeout(idle_timeout)
+        try:
+            while True:
+                try:
+                    (b1,) = struct.unpack("!B", self._recv_exact(1))
+                except (socket.timeout, TimeoutError):
+                    break
+                rem = self._recv_remaining_length()
+                body = self._recv_exact(rem) if rem else b""
+                if (b1 >> 4) != 3:  # only care about PUBLISH
+                    continue
+                retain = b1 & 0x01
+                qos = (b1 >> 1) & 0x03
+                (tlen,) = struct.unpack("!H", body[:2])
+                topic = body[2 : 2 + tlen].decode("utf-8", "replace")
+                rest = body[2 + tlen :]
+                if qos > 0:
+                    pkt_id = rest[:2]
+                    rest = rest[2:]
+                    self._send(b"\x40\x02" + pkt_id)  # PUBACK (QoS 1)
+                if retain:
+                    retained[topic] = rest
+        finally:
+            self._sock.settimeout(self._timeout)
+        return retained
+
+    def publish_clear_retained(self, topic):
+        """Publish a zero-length retained message (QoS 0) - this deletes the
+        retained value for the topic on the broker."""
+        body = _enc_str(topic)  # no packet id (QoS 0), empty payload
+        self._send(b"\x31" + _enc_remaining_length(len(body)) + body)
+
+    def disconnect(self):
+        try:
+            self._send(b"\xe0\x00")
+        except OSError:
+            pass
+        try:
+            self._sock.close()
+        except OSError:
+            pass
+
+
+# --------------------------------------------------------------------------
+# Topic matching
+# --------------------------------------------------------------------------
+def is_device_config_topic(topic, ha_prefix, unique_id):
+    segs = topic.split("/")
+    return (
+        len(segs) >= 3
+        and segs[0] == ha_prefix
+        and segs[-1] == "config"
+        and unique_id in segs
+    )
+
+
+# --------------------------------------------------------------------------
+# CLI
+# --------------------------------------------------------------------------
+def build_parser():
+    p = argparse.ArgumentParser(
+        prog="wipe_ha_discovery",
+        description="Wipe retained Home Assistant MQTT discovery (config) "
+        "topics for one OTGW device.",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+    p.add_argument(
+        "--host",
+        default=DEFAULT_HOST,
+        help="OTGW hostname/IP for REST auto-discovery",
+    )
+    p.add_argument("--http-user", default="admin", help="OTGW HTTP auth user")
+    p.add_argument(
+        "--http-pass",
+        default=None,
+        help="OTGW HTTP auth password (only if one is set on the OTGW)",
+    )
+    p.add_argument("--broker", default=None, help="MQTT broker host (overrides REST)")
+    p.add_argument("--port", type=int, default=None, help="MQTT broker port")
+    p.add_argument("--mqtt-user", default=None, help="MQTT username")
+    p.add_argument(
+        "--mqtt-pass",
+        default=None,
+        help="MQTT password (prompted if a user is set and this is omitted)",
+    )
+    p.add_argument(
+        "--unique-id",
+        default=None,
+        help="Device unique_id / node id (overrides REST discovery)",
+    )
+    p.add_argument(
+        "--ha-prefix",
+        default=None,
+        help="Home Assistant discovery prefix (overrides REST discovery)",
+    )
+    p.add_argument(
+        "--rest-timeout", type=float, default=5.0, help="REST request timeout (s)"
+    )
+    p.add_argument(
+        "--mqtt-timeout",
+        type=float,
+        default=10.0,
+        help="MQTT connect/network timeout (s)",
+    )
+    p.add_argument(
+        "--collect-timeout",
+        type=float,
+        default=3.0,
+        help="Idle seconds to wait for retained messages after subscribe",
+    )
+    p.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="List matching topics and exit without wiping",
+    )
+    p.add_argument(
+        "-y",
+        "--yes",
+        action="store_true",
+        help="Skip the interactive confirmation dialog (non-interactive use)",
+    )
+    return p
+
+
+def confirm(matched, ctx):
+    print()
+    print("About to WIPE retained Home Assistant discovery topics:")
+    print(f"  OTGW host    : {ctx['host']}")
+    print(f"  MQTT broker  : {ctx['broker']}:{ctx['port']}")
+    print(f"  HA prefix    : {ctx['ha_prefix']}")
+    print(f"  Device id    : {ctx['unique_id']}{ctx['id_note']}")
+    print(f"  Topics found : {len(matched)}")
+    print()
+    for t in matched:
+        print(f"    - {t}")
+    print()
+    print(
+        "This permanently removes these retained config topics from the "
+        "broker.\nHome Assistant will drop the matching entities."
+    )
+    try:
+        answer = input('Type "WIPE" to confirm, anything else to abort: ')
+    except (EOFError, KeyboardInterrupt):
+        print()
+        return False
+    return answer.strip() == "WIPE"
+
+
+def main(argv=None):
+    args = build_parser().parse_args(argv)
+
+    print(f"Discovering OTGW configuration via REST at http://{args.host} ...")
+    rest = {}
+    try:
+        rest = discover_from_rest(
+            args.host, args.http_user, args.http_pass, args.rest_timeout
+        )
+    except socket.gaierror:
+        print(
+            f"  Could not resolve '{args.host}'. If mDNS (.local) is "
+            "unavailable, pass --host <ip-address>.",
+            file=sys.stderr,
+        )
+
+    unique_id = args.unique_id or rest.get("unique_id")
+    ha_prefix = args.ha_prefix or rest.get("ha_prefix") or DEFAULT_HA_PREFIX
+    broker = args.broker or rest.get("broker")
+    port = args.port or rest.get("port") or DEFAULT_MQTT_PORT
+    mqtt_user = args.mqtt_user or rest.get("mqtt_user")
+
+    id_note = ""
+    if not args.unique_id and rest.get("unique_id_is_default"):
+        id_note = "  (derived default from MAC; pass --unique-id if customised)"
+
+    if rest.get("hostname"):
+        print(f"  OTGW hostname : {rest['hostname']}")
+    if not unique_id:
+        print(
+            "ERROR: could not determine the device unique_id from REST. "
+            "Provide it explicitly with --unique-id.",
+            file=sys.stderr,
+        )
+        return 2
+    if not broker:
+        print(
+            "ERROR: could not determine the MQTT broker from REST "
+            "(the debug/settings endpoint may be HTTP-auth protected). "
+            "Provide --broker (and --http-pass to read it via REST).",
+            file=sys.stderr,
+        )
+        return 2
+
+    print(f"  unique_id     : {unique_id}{id_note}")
+    print(f"  ha_prefix     : {ha_prefix}")
+    print(f"  broker        : {broker}:{port}")
+
+    mqtt_pass = args.mqtt_pass
+    if mqtt_user and mqtt_pass is None and not args.yes:
+        try:
+            mqtt_pass = getpass.getpass(f"MQTT password for '{mqtt_user}': ")
+        except (EOFError, KeyboardInterrupt):
+            print()
+            return 1
+
+    print(f"Connecting to MQTT broker {broker}:{port} ...")
+    try:
+        client = MiniMQTT(broker, port, args.mqtt_timeout)
+        client.connect(
+            client_id="otgwwipe-" + os.urandom(3).hex(),
+            username=mqtt_user,
+            password=mqtt_pass,
+        )
+    except (OSError, MqttError) as exc:
+        print(f"ERROR: MQTT connection failed: {exc}", file=sys.stderr)
+        return 3
+
+    try:
+        sub = f"{ha_prefix}/#"
+        print(f"Subscribing to '{sub}' and collecting retained topics ...")
+        client.subscribe(sub)
+        retained = client.collect_retained(args.collect_timeout)
+        matched = sorted(
+            t for t in retained if is_device_config_topic(t, ha_prefix, unique_id)
+        )
+
+        if not matched:
+            print(
+                f"No retained discovery topics found for '{unique_id}' "
+                f"under '{ha_prefix}/'. Nothing to wipe."
+            )
+            return 0
+
+        ctx = {
+            "host": args.host,
+            "broker": broker,
+            "port": port,
+            "ha_prefix": ha_prefix,
+            "unique_id": unique_id,
+            "id_note": id_note,
+        }
+
+        if args.dry_run:
+            print(f"\n[dry-run] {len(matched)} topic(s) would be wiped:")
+            for t in matched:
+                print(f"    - {t}")
+            return 0
+
+        if not args.yes:
+            if not confirm(matched, ctx):
+                print("Aborted - nothing was changed.")
+                return 1
+
+        wiped = 0
+        for t in matched:
+            client.publish_clear_retained(t)
+            wiped += 1
+        print(f"Wiped {wiped} retained discovery topic(s) for '{unique_id}'.")
+        return 0
+    except (OSError, MqttError) as exc:
+        print(f"ERROR: MQTT operation failed: {exc}", file=sys.stderr)
+        return 3
+    finally:
+        client.disconnect()
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/wipe_ha_discovery.sh
+++ b/scripts/wipe_ha_discovery.sh
@@ -1,0 +1,84 @@
+#!/bin/sh
+# Launcher for wipe_ha_discovery.py (Linux/macOS).
+# Finds a Python 3 interpreter and, if none is present, attempts to install
+# one with the system package manager before running the wiper.
+# Set WIPE_HA_NO_AUTOINSTALL=1 to disable the auto-install step.
+
+set -eu
+
+SCRIPT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+PY_SCRIPT="$SCRIPT_DIR/wipe_ha_discovery.py"
+
+find_python() {
+    for c in python3 python; do
+        if command -v "$c" >/dev/null 2>&1 &&
+           "$c" -c 'import sys; raise SystemExit(0 if sys.version_info[0] == 3 else 1)' >/dev/null 2>&1; then
+            echo "$c"
+            return 0
+        fi
+    done
+    return 1
+}
+
+sudo_prefix() {
+    if [ "$(id -u)" -eq 0 ]; then
+        echo ""
+    elif command -v sudo >/dev/null 2>&1; then
+        echo "sudo"
+    else
+        echo ""
+    fi
+}
+
+auto_install() {
+    SUDO=$(sudo_prefix)
+    if [ "$(uname -s)" = "Darwin" ]; then
+        if command -v brew >/dev/null 2>&1; then
+            echo "Installing Python 3 via Homebrew ..."
+            brew install python3 || return 1
+        else
+            return 1
+        fi
+    elif command -v apt-get >/dev/null 2>&1; then
+        echo "Installing Python 3 via apt-get ..."
+        $SUDO apt-get update && $SUDO apt-get install -y python3 || return 1
+    elif command -v dnf >/dev/null 2>&1; then
+        echo "Installing Python 3 via dnf ..."
+        $SUDO dnf install -y python3 || return 1
+    elif command -v yum >/dev/null 2>&1; then
+        echo "Installing Python 3 via yum ..."
+        $SUDO yum install -y python3 || return 1
+    elif command -v pacman >/dev/null 2>&1; then
+        echo "Installing Python 3 via pacman ..."
+        $SUDO pacman -Sy --noconfirm python || return 1
+    elif command -v zypper >/dev/null 2>&1; then
+        echo "Installing Python 3 via zypper ..."
+        $SUDO zypper install -y python3 || return 1
+    elif command -v apk >/dev/null 2>&1; then
+        echo "Installing Python 3 via apk ..."
+        $SUDO apk add python3 || return 1
+    else
+        return 1
+    fi
+    return 0
+}
+
+if PY=$(find_python); then
+    :
+else
+    if [ "${WIPE_HA_NO_AUTOINSTALL:-0}" = "1" ]; then
+        echo "Python 3 not found and auto-install disabled." >&2
+        echo "Install Python 3 from https://www.python.org/downloads/ and re-run." >&2
+        exit 1
+    fi
+    echo "Python 3 not found. Attempting to install it ..."
+    if auto_install && PY=$(find_python); then
+        echo "Python 3 installed successfully."
+    else
+        echo "Could not auto-install Python 3 on this system." >&2
+        echo "Install it manually from https://www.python.org/downloads/ (or via your package manager) and re-run." >&2
+        exit 1
+    fi
+fi
+
+exec "$PY" "$PY_SCRIPT" "$@"


### PR DESCRIPTION
## Summary

Adds a **standalone, dependency-free** utility that clears an OTGW's *retained* Home Assistant MQTT discovery (`config`) topics. After removing or renaming an OTGW, stale retained `<ha_prefix>/<component>/<unique_id>/.../config` topics keep ghost entities alive in Home Assistant — this script removes exactly those, scoped to a single device.

## Changes

- **`scripts/wipe_ha_discovery.py`** — stdlib-only (no `pip` install).
  - Auto-discovers `unique_id` / `ha_prefix` / `broker` / `port` / `mqtt_user` via the OTGW REST API: `/api/v2/debug` → `/api/v2/settings` → `/api/v2/device/info` (the last is unauthenticated and lets the script reconstruct the firmware default `otgw-<MAC>`). Host defaults to `OTGW.local`; every value is overridable via CLI flags.
  - Minimal MQTT 3.1.1 client (CONNECT / SUBSCRIBE / PUBLISH / DISCONNECT) over stdlib sockets.
  - **Scope safety:** only retained topics whose last path segment is `config` *and* that contain the resolved `unique_id` as a path segment are touched — other devices on a shared broker are never affected.
  - Requires an explicit typed **`WIPE`** confirmation dialog; supports `--dry-run` (list only) and `--yes` (non-interactive). Clears each topic with a zero-length retained publish and reports the count.
- **`scripts/wipe_ha_discovery.sh` / `.bat`** — launchers that locate Python 3 and auto-install it when absent (apt/dnf/yum/pacman/zypper/apk/brew; winget/choco on Windows), with `WIPE_HA_NO_AUTOINSTALL=1` opt-out and manual-install fallback messaging.

## Test plan

- [x] `python3 -m py_compile` and `sh -n` syntax checks pass
- [x] `--help` renders correctly
- [x] End-to-end against an in-process MQTT broker stub: only the target device's `config` topics are cleared; a second device's topic and non-`config` topics are excluded
- [x] Clears use the retain flag with an empty payload
- [x] `--dry-run` and a declined confirmation publish nothing; declined confirmation exits non-zero
- [ ] Field validation against a real broker + Home Assistant (hardware-in-the-loop)

Tooling-only change (`scripts/**`): exempt from version bump and firmware build/evaluator gates per project policy.

https://claude.ai/code/session_019J4NERNKiyTwLApHzU1mAD

---
_Generated by [Claude Code](https://claude.ai/code/session_019J4NERNKiyTwLApHzU1mAD)_