### PR TITLE
docs: add openHAB and Domoticz integration guides

### DIFF
--- a/backlog/tasks/task-616 - Add-openHAB-and-Domoticz-integration-guides-HA-discovery-consumers.md
+++ b/backlog/tasks/task-616 - Add-openHAB-and-Domoticz-integration-guides-HA-discovery-consumers.md
@@ -1,0 +1,26 @@
+---
+id: TASK-616
+title: Add openHAB and Domoticz integration guides (HA discovery consumers)
+status: To Do
+assignee: []
+created_date: '2026-05-17 07:22'
+labels:
+  - documentation
+  - mqtt
+dependencies: []
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+OTGW already emits Home Assistant MQTT Discovery under a configurable prefix (settings.mqtt.sHaprefix). openHAB (MQTT binding + HomeAssistant MQTT Components binding) and Domoticz (MQTT Auto Discovery Client hardware) both consume that same HA discovery format. No firmware change is needed to support them - what is missing is user-facing documentation. Add two docs/guides pages mirroring EMS-ESP's openHAB/Domoticz docs, and cross-link them from the MQTT API reference.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 docs/guides/OPENHAB.md exists and documents: required openHAB bindings (MQTT + HomeAssistant MQTT Components), how the discovery prefix maps to settings.mqtt.sHaprefix (default homeassistant), Thing grouping via device identifiers, and the trusted-LAN/no-auth security note
+- [ ] #2 docs/guides/DOMOTICZ.md exists and documents: the MQTT Auto Discovery Client hardware setup, discovery-prefix mapping to settings.mqtt.sHaprefix, and an explicit do-not-use warning for the legacy domoticz/in idx protocol (YAGNI)
+- [ ] #3 Both guides accurately reflect the discovery topic pattern {haprefix}/{component}/{node_id}/{object_id}/config and cross-link to docs/api/MQTT.md Home Assistant Auto-Discovery section
+- [ ] #4 docs/api/MQTT.md links out to the two new guides
+- [ ] #5 Change is docs-only (no src/ firmware files touched) so it is version-bump and ADR exempt
+<!-- AC:END -->

--- a/backlog/tasks/task-616 - Add-openHAB-and-Domoticz-integration-guides-HA-discovery-consumers.md
+++ b/backlog/tasks/task-616 - Add-openHAB-and-Domoticz-integration-guides-HA-discovery-consumers.md
@@ -1,11 +1,11 @@
 ---
 id: TASK-616
 title: Add openHAB and Domoticz integration guides (HA discovery consumers)
-status: In Progress
+status: Done
 assignee:
   - '@claude'
 created_date: '2026-05-17 07:22'
-updated_date: '2026-05-17 07:22'
+updated_date: '2026-05-17 07:24'
 labels:
   - documentation
   - mqtt
@@ -20,11 +20,11 @@ OTGW already emits Home Assistant MQTT Discovery under a configurable prefix (se
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 docs/guides/OPENHAB.md exists and documents: required openHAB bindings (MQTT + HomeAssistant MQTT Components), how the discovery prefix maps to settings.mqtt.sHaprefix (default homeassistant), Thing grouping via device identifiers, and the trusted-LAN/no-auth security note
-- [ ] #2 docs/guides/DOMOTICZ.md exists and documents: the MQTT Auto Discovery Client hardware setup, discovery-prefix mapping to settings.mqtt.sHaprefix, and an explicit do-not-use warning for the legacy domoticz/in idx protocol (YAGNI)
-- [ ] #3 Both guides accurately reflect the discovery topic pattern {haprefix}/{component}/{node_id}/{object_id}/config and cross-link to docs/api/MQTT.md Home Assistant Auto-Discovery section
-- [ ] #4 docs/api/MQTT.md links out to the two new guides
-- [ ] #5 Change is docs-only (no src/ firmware files touched) so it is version-bump and ADR exempt
+- [x] #1 docs/guides/OPENHAB.md exists and documents: required openHAB bindings (MQTT + HomeAssistant MQTT Components), how the discovery prefix maps to settings.mqtt.sHaprefix (default homeassistant), Thing grouping via device identifiers, and the trusted-LAN/no-auth security note
+- [x] #2 docs/guides/DOMOTICZ.md exists and documents: the MQTT Auto Discovery Client hardware setup, discovery-prefix mapping to settings.mqtt.sHaprefix, and an explicit do-not-use warning for the legacy domoticz/in idx protocol (YAGNI)
+- [x] #3 Both guides accurately reflect the discovery topic pattern {haprefix}/{component}/{node_id}/{object_id}/config and cross-link to docs/api/MQTT.md Home Assistant Auto-Discovery section
+- [x] #4 docs/api/MQTT.md links out to the two new guides
+- [x] #5 Change is docs-only (no src/ firmware files touched) so it is version-bump and ADR exempt
 <!-- AC:END -->
 
 ## Implementation Plan
@@ -35,3 +35,16 @@ OTGW already emits Home Assistant MQTT Discovery under a configurable prefix (se
 3. Cross-link both to docs/api/MQTT.md HA Auto-Discovery section; add reciprocal links from MQTT.md
 4. Commit (docs-only, bump/ADR exempt), push, open draft PR
 <!-- SECTION:PLAN:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Added two integration guides documenting that OTGW's existing Home Assistant MQTT Discovery is consumed as-is by openHAB and Domoticz — no firmware change required.
+
+Changes:
+- docs/guides/OPENHAB.md: MQTT + HomeAssistant MQTT Components bindings, prefix matching via settings.mqtt.sHaprefix, device-identifier Thing grouping, ADR-071 topic-shape note, trusted-LAN security caveat, troubleshooting table.
+- docs/guides/DOMOTICZ.md: MQTT Auto Discovery Client hardware setup, prefix matching, explicit do-not-use warning for the legacy domoticz/in idx protocol, troubleshooting table.
+- docs/api/MQTT.md: callout linking both new guides from the HA Auto-Discovery section.
+
+Docs-only (no src/ touched) — version-bump and ADR exempt. No code change because the audit confirmed both consumers ingest the HA discovery format directly.
+<!-- SECTION:FINAL_SUMMARY:END -->

--- a/backlog/tasks/task-616 - Add-openHAB-and-Domoticz-integration-guides-HA-discovery-consumers.md
+++ b/backlog/tasks/task-616 - Add-openHAB-and-Domoticz-integration-guides-HA-discovery-consumers.md
@@ -1,9 +1,11 @@
 ---
 id: TASK-616
 title: Add openHAB and Domoticz integration guides (HA discovery consumers)
-status: To Do
-assignee: []
+status: In Progress
+assignee:
+  - '@claude'
 created_date: '2026-05-17 07:22'
+updated_date: '2026-05-17 07:22'
 labels:
   - documentation
   - mqtt
@@ -24,3 +26,12 @@ OTGW already emits Home Assistant MQTT Discovery under a configurable prefix (se
 - [ ] #4 docs/api/MQTT.md links out to the two new guides
 - [ ] #5 Change is docs-only (no src/ firmware files touched) so it is version-bump and ADR exempt
 <!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Write docs/guides/OPENHAB.md: bindings to install, prefix=settings.mqtt.sHaprefix, device-identifier Thing grouping, ADR-071 topic shape note, trusted-LAN security caveat, troubleshooting
+2. Write docs/guides/DOMOTICZ.md: MQTT Auto Discovery Client hardware setup, prefix mapping, explicit do-not-use legacy domoticz/in idx warning, troubleshooting
+3. Cross-link both to docs/api/MQTT.md HA Auto-Discovery section; add reciprocal links from MQTT.md
+4. Commit (docs-only, bump/ADR exempt), push, open draft PR
+<!-- SECTION:PLAN:END -->

--- a/backlog/tasks/task-619 - Fix-2-pre-existing-PROGMEM-flash-string-violations-failing-evaluate.py-CI-gate.md
+++ b/backlog/tasks/task-619 - Fix-2-pre-existing-PROGMEM-flash-string-violations-failing-evaluate.py-CI-gate.md
@@ -1,0 +1,28 @@
+---
+id: TASK-619
+title: Fix 2 pre-existing PROGMEM flash-string violations failing evaluate.py CI gate
+status: To Do
+assignee: []
+created_date: '2026-05-17 13:23'
+labels:
+  - bug
+  - firmware
+  - progmem
+  - ci
+dependencies: []
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+python evaluate.py --quick fails the '[PROGMEM] Flash string compliance' check with 'Found 2 PROGMEM violations (wastes RAM)'. The evaluate.py CI workflow (.github/workflows/evaluate.yml) has a gate step that exits 1 on ANY evaluate.py failure, so this single pre-existing firmware-lint failure red-gates EVERY PR to the dev line (observed on docs-only PR #590). The same failure is present on the 2.0.0 base branch (a sibling port task is recommended). These are string literals not kept in flash, per the project PROGMEM-mandatory rule (ESP8266 ~40KB RAM). Locate and fix both so the literals live in flash (F()/PSTR()/PROGMEM/snprintf_P as appropriate) with no behaviour change.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 The 2 PROGMEM violations flagged by 'python evaluate.py --quick' on dev are located and their file:line documented in the task implementation notes
+- [ ] #2 Each violation fixed so the string literal is stored in flash per the project PROGMEM rules, with no functional/behavioural change
+- [ ] #3 'python evaluate.py --quick' reports 0 failed checks on dev (the [PROGMEM] Flash string compliance check passes)
+- [ ] #4 'python build.py --firmware' exits 0 (firmware compiles clean)
+- [ ] #5 The implementing commit bumps _VERSION_PRERELEASE per the versioning policy (staged paths include src/OTGW-firmware/**)
+<!-- AC:END -->

--- a/docs/api/MQTT.md
+++ b/docs/api/MQTT.md
@@ -479,6 +479,8 @@ Commands can also be sent using the two-letter OTGW command codes directly as to
 
 The firmware supports Home Assistant MQTT auto-discovery, publishing discovery configuration messages to the `{haprefix}/` topic tree (default: `homeassistant/`).
 
+> **Other consumers of this discovery format:** openHAB and Domoticz both ingest the Home Assistant MQTT Discovery convention directly — no firmware change is needed. See [`docs/guides/OPENHAB.md`](../guides/OPENHAB.md) and [`docs/guides/DOMOTICZ.md`](../guides/DOMOTICZ.md) for setup.
+
 ### Discovery Configuration
 
 Discovery topics follow the pattern:

--- a/docs/guides/DOMOTICZ.md
+++ b/docs/guides/DOMOTICZ.md
@@ -1,0 +1,79 @@
+# Using OTGW-firmware with Domoticz
+
+This guide explains how to integrate the OpenTherm Gateway with [Domoticz](https://www.domoticz.com/) over MQTT.
+
+## TL;DR — no firmware change needed
+
+OTGW-firmware already publishes **Home Assistant MQTT Discovery** messages. Modern Domoticz can ingest those messages directly through its **MQTT Auto Discovery Client** hardware type. No OTGW firmware change and no per-device mapping is required — point Domoticz at the same broker and discovery prefix that OTGW uses.
+
+> **Do NOT use the legacy `domoticz/in` path.** Domoticz also has an older native MQTT protocol that publishes/consumes `domoticz/in` and `domoticz/out` with per-device numeric `idx` JSON. OTGW does **not** publish to `domoticz/in`, and you should not try to bridge it there. That path is stateful, requires manually creating every device and mapping `idx` values by hand, and is entirely superseded by the Auto Discovery Client. Use the discovery path described below.
+
+## Prerequisites
+
+- A running MQTT broker (e.g. Mosquitto) reachable by both OTGW and Domoticz.
+- OTGW MQTT enabled and connected (Settings → MQTT). Confirm with `mosquitto_sub -h <broker> -v -t '<haprefix>/#'` — you should see retained `.../config` messages.
+- A recent Domoticz release (the *MQTT Auto Discovery Client Gateway* hardware type, which supports the Home Assistant discovery convention).
+
+## Step 1 — Add the Auto Discovery Client hardware
+
+In Domoticz: **Setup → Hardware**, add:
+
+> **Type:** `MQTT Auto Discovery Client Gateway with LAN interface`
+
+Fill in:
+
+- **Remote Address / Port**: your MQTT broker.
+- **Username / Password**: if your broker requires them.
+- **Auto Discovery Prefix**: the topic root Domoticz watches (default `homeassistant`).
+
+## Step 2 — Match the discovery prefix
+
+Domoticz's *Auto Discovery Prefix* must equal OTGW's discovery prefix, the setting **`settings.mqtt.sHaprefix`** (Web UI: *MQTT → HA prefix*; REST/JSON key `mqtthaprefix` / `MQTThaprefix`).
+
+| Side | Setting | Default |
+|------|---------|---------|
+| OTGW | `settings.mqtt.sHaprefix` | `homeassistant` |
+| Domoticz | Auto Discovery Client → *Auto Discovery Prefix* | `homeassistant` |
+
+With defaults on both sides, no change is needed. If you customised either, set both to the same string.
+
+## Step 3 — Enable the discovered devices
+
+After the hardware is added and the broker connects, OTGW's entities appear under **Setup → Devices**. Domoticz keeps newly discovered devices inactive until you enable them — find the OTGW entities and click the green arrow to add each one you want, then use them on the Dashboard / in scenes.
+
+## How the topics line up
+
+OTGW publishes discovery configs to (see [`docs/api/MQTT.md`](../api/MQTT.md) → *Home Assistant Auto-Discovery*):
+
+```
+{haprefix}/{component}/{node_id}/{object_id}/config
+```
+
+- `{haprefix}` = `settings.mqtt.sHaprefix` (default `homeassistant`)
+- `{component}` = `sensor`, `binary_sensor`, `climate`, `number`
+- `{object_id}` is a flat, sibling-suffixed identifier matching `[a-zA-Z0-9_-]+` (ADR-071)
+
+Entity **availability** uses the MQTT LWT/birth message (`avty_t` → `online`/`offline`); see [`MQTT_LWT.md`](MQTT_LWT.md). Discovery configs are **retained** on the broker (ADR-062/ADR-073), so Domoticz rediscovers everything after a Domoticz restart without an OTGW republish.
+
+## Caveats
+
+- **Subset support.** Domoticz's Auto Discovery Client implements a subset of the Home Assistant discovery spec. OTGW stays within the common, standard subset, so its entities map; any future HA-only construct would simply not produce a Domoticz device.
+- **Retained configs are required.** If retained topics are cleared on the broker, trigger a republish from OTGW (Web UI / `POST /api/v2/otgw/discovery`) so Domoticz can rediscover.
+- **One integration path only.** Use the Auto Discovery Client *or* nothing — never additionally try to wire OTGW into `domoticz/in`. There is no OTGW support for it by design (YAGNI: the discovery path already covers every entity).
+- **Security.** Plain-MQTT, trusted-LAN integration only. OTGW uses HTTP/MQTT and assumes a local, non-internet-exposed network; use a VPN for remote access.
+
+## Troubleshooting
+
+| Symptom | Likely cause / fix |
+|---------|--------------------|
+| No OTGW devices appear | Prefix mismatch — confirm `settings.mqtt.sHaprefix` equals the *Auto Discovery Prefix*. Verify configs exist: `mosquitto_sub -v -t '<haprefix>/#'`. |
+| Devices appear but show no value | They exist as discovery configs but the value hasn't been published yet (JIT discovery, ADR-073) — values arrive once the MsgID is seen on the OpenTherm bus. |
+| Device shows as "off"/unavailable | Availability topic not received — check the LWT/birth topic publishes `online` (see `MQTT_LWT.md`). |
+| Duplicate / stale devices | Old retained configs from a previous topic shape. Clear zombie/orphan retained configs per the migration notes in `docs/api/MQTT.md`, then republish. |
+
+## Related
+
+- [`docs/api/MQTT.md`](../api/MQTT.md) — authoritative MQTT topic & discovery reference
+- [`MQTT_LWT.md`](MQTT_LWT.md) — availability (online/offline) mechanism
+- [`OPENHAB.md`](OPENHAB.md) — the equivalent guide for openHAB
+- Domoticz docs: [MQTT Auto Discovery](https://www.domoticz.com/wiki/MQTT)

--- a/docs/guides/OPENHAB.md
+++ b/docs/guides/OPENHAB.md
@@ -1,0 +1,77 @@
+# Using OTGW-firmware with openHAB
+
+This guide explains how to integrate the OpenTherm Gateway with [openHAB](https://www.openhab.org/) over MQTT.
+
+## TL;DR — no firmware change needed
+
+OTGW-firmware already publishes **Home Assistant MQTT Discovery** messages. openHAB does **not** have its own discovery format — its MQTT binding *consumes* the Home Assistant discovery convention directly. So integration is purely an openHAB-side configuration task: point openHAB at the same broker and the same discovery prefix that OTGW uses, and every entity appears automatically.
+
+## Prerequisites
+
+- A running MQTT broker (e.g. Mosquitto) reachable by both OTGW and openHAB.
+- OTGW MQTT enabled and connected (Settings → MQTT). Confirm the device is publishing — e.g. `mosquitto_sub -h <broker> -v -t '<haprefix>/#'` shows retained `.../config` messages.
+- openHAB 3.x or 4.x.
+
+## Step 1 — Install the bindings
+
+In openHAB, install:
+
+1. **MQTT Binding** (`org.openhab.binding.mqtt`)
+2. **HomeAssistant MQTT Components** support — bundled with the MQTT binding in OH3/OH4 (the `mqtt.homeassistant` discovery component). No separate add-on is needed on current openHAB; on older versions install it explicitly.
+
+## Step 2 — Create the MQTT Broker Thing
+
+Add an **MQTT Broker** Thing pointing at your broker (host, port, and credentials if used). Once it is `ONLINE`, openHAB starts listening for Home Assistant discovery messages.
+
+## Step 3 — Match the discovery prefix
+
+openHAB's Home Assistant discovery defaults to the base topic **`homeassistant`**. OTGW's discovery prefix is the setting **`settings.mqtt.sHaprefix`** (Web UI: *MQTT → HA prefix*; REST/JSON key `mqtthaprefix` / `MQTThaprefix`), which also defaults to `homeassistant`.
+
+| Side | Setting | Default |
+|------|---------|---------|
+| OTGW | `settings.mqtt.sHaprefix` | `homeassistant` |
+| openHAB | MQTT binding HA discovery base topic | `homeassistant` |
+
+If you changed either value, set **both** to the same string. With defaults, no change is needed.
+
+## Step 4 — Accept the discovered Things
+
+OTGW-discovered entities appear in the openHAB **Inbox**. All entities that share the same MQTT `device.identifiers` value are grouped into a **single Thing**; each entity becomes a **Channel** (components are exposed as Channel Groups). Add the Thing from the Inbox and link its Channels to Items as usual.
+
+## How the topics line up
+
+OTGW publishes discovery configs to (see [`docs/api/MQTT.md`](../api/MQTT.md) → *Home Assistant Auto-Discovery*):
+
+```
+{haprefix}/{component}/{node_id}/{object_id}/config
+```
+
+- `{haprefix}` = `settings.mqtt.sHaprefix` (default `homeassistant`)
+- `{component}` = `sensor`, `binary_sensor`, `climate`, `number`
+- `{object_id}` is a flat, sibling-suffixed identifier matching `[a-zA-Z0-9_-]+` (ADR-071) — the same constraint openHAB's discovery topic matcher expects, so per-source variants like `..._thermostat` map cleanly.
+
+Entity **availability** is driven by the MQTT LWT/birth message (`avty_t` → `online`/`offline`); see [`MQTT_LWT.md`](MQTT_LWT.md). openHAB marks Channels `UNDEF`/offline accordingly.
+
+Discovery configs are **retained** on the broker (ADR-062/ADR-073), so openHAB rediscovers everything after an openHAB restart without needing OTGW to republish.
+
+## Caveats
+
+- **Subset support.** openHAB's Home Assistant component implementation tracks the standard, documented HA components and abbreviated keys. OTGW deliberately stays inside that common subset (`sensor`/`binary_sensor`/`climate`/`number` with standard keys), so all OTGW entities map. If a future entity uses an HA-only construct, openHAB silently skips just that entity.
+- **Retained configs are required.** If you wipe retained topics on the broker, trigger a republish from OTGW (Web UI / `POST /api/v2/otgw/discovery`) so openHAB can rediscover.
+- **Security.** This is a plain-MQTT, trusted-LAN integration. OTGW uses HTTP/MQTT only and assumes a local, non-internet-exposed network; use a VPN for remote access. Do not expose the broker to the internet.
+
+## Troubleshooting
+
+| Symptom | Likely cause / fix |
+|---------|--------------------|
+| Nothing in the Inbox | Prefix mismatch — confirm `settings.mqtt.sHaprefix` equals openHAB's HA discovery base topic. Verify configs exist: `mosquitto_sub -v -t '<haprefix>/#'`. |
+| Thing appears but Channels are offline | Availability topic not seen. Check the device's LWT/birth topic is publishing `online` (see `MQTT_LWT.md`). |
+| Some entities missing | Those entities not yet seen on the OpenTherm bus (JIT discovery, ADR-073) — they appear once their MsgID is received. Or the entity uses a construct outside openHAB's supported subset. |
+| Stale Things after a topic-shape change | Clear zombie/orphan retained configs as documented in `docs/api/MQTT.md` (migration notes), then republish. |
+
+## Related
+
+- [`docs/api/MQTT.md`](../api/MQTT.md) — authoritative MQTT topic & discovery reference
+- [`MQTT_LWT.md`](MQTT_LWT.md) — availability (online/offline) mechanism
+- [`DOMOTICZ.md`](DOMOTICZ.md) — the equivalent guide for Domoticz
+- openHAB docs: [Home Assistant binding](https://www.openhab.org/addons/bindings/homeassistant/)


### PR DESCRIPTION
## Summary

- OTGW already emits Home Assistant MQTT Discovery under a configurable prefix (`settings.mqtt.sHaprefix`). openHAB and Domoticz both **consume that same discovery format directly** — so broadening to them is a documentation task, not a firmware change.
- Adds `docs/guides/OPENHAB.md` — MQTT + HomeAssistant MQTT Components bindings, prefix matching, device-identifier Thing grouping, ADR-071 topic-shape note, trusted-LAN security caveat, troubleshooting.
- Adds `docs/guides/DOMOTICZ.md` — MQTT Auto Discovery Client hardware setup, prefix matching, and an explicit do-not-use warning for the legacy `domoticz/in` idx protocol (YAGNI).
- Cross-links both guides from the `docs/api/MQTT.md` Home Assistant Auto-Discovery section.

Backlog: TASK-616. Inspired by the EMS-ESP comparison (one HA-discovery format, multiple consumers).

## Test plan

- [ ] Docs-only change — no `src/` files touched (version-bump and ADR exempt by policy).
- [ ] Markdown renders correctly on GitHub; relative links resolve (`../api/MQTT.md`, `MQTT_LWT.md`, sibling guides).
- [ ] Field check (optional): a maintainer with openHAB / Domoticz confirms the discovered entities appear following the documented steps.

https://claude.ai/code/session_01Tp7DG8BufLYs9a6e8P9YET

---
_Generated by [Claude Code](https://claude.ai/code/session_01Tp7DG8BufLYs9a6e8P9YET)_