### PR TITLE
Fix false-positive and stale checks in evaluate.py

### DIFF
--- a/backlog/tasks/task-608 - Resolve-4-unresolved-ADR-references-flagged-by-evaluate.py-quick-dev-baseline.md
+++ b/backlog/tasks/task-608 - Resolve-4-unresolved-ADR-references-flagged-by-evaluate.py-quick-dev-baseline.md
@@ -7,7 +7,7 @@ status: In Progress
 assignee:
   - '@claude'
 created_date: '2026-05-16 07:26'
-updated_date: '2026-05-17 10:03'
+updated_date: '2026-05-17 10:04'
 labels:
   - ci
   - tech-debt
@@ -27,3 +27,11 @@ evaluate.py --quick fails the [ADR] References resolve check with '4 unresolved 
 - [ ] #3 python evaluate.py --quick reports the [ADR] References resolve check as passing (0 unresolved out of total)
 - [ ] #4 python evaluate.py --quick shows no new failures vs the documented baseline (Health Score improves; Failed count for this check is 0)
 <!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Confirm the 4 unresolved refs: README.md:33->ADR-063 (documented reserved no-op), ADR-070:66->ADR-097 and ADR-072:65/85->ADR-099 (cross-worktree refs to 2.0.0 line)
+2. Resolution path: none are dev-tree ADRs that should exist; fix check_adr_references_resolve to recognize reserved/skipped/unused numbers and cross-worktree (2.0.0/worktree/sibling/port) refs via the existing escape-hatch mechanism
+3. Run evaluate.py --quick to confirm 0 unresolved
+<!-- SECTION:PLAN:END -->

--- a/backlog/tasks/task-608 - Resolve-4-unresolved-ADR-references-flagged-by-evaluate.py-quick-dev-baseline.md
+++ b/backlog/tasks/task-608 - Resolve-4-unresolved-ADR-references-flagged-by-evaluate.py-quick-dev-baseline.md
@@ -3,7 +3,7 @@ id: TASK-608
 title: >-
   Resolve 4 unresolved ADR references flagged by evaluate.py --quick (dev
   baseline)
-status: In Progress
+status: Done
 assignee:
   - '@claude'
 created_date: '2026-05-16 07:26'

--- a/backlog/tasks/task-608 - Resolve-4-unresolved-ADR-references-flagged-by-evaluate.py-quick-dev-baseline.md
+++ b/backlog/tasks/task-608 - Resolve-4-unresolved-ADR-references-flagged-by-evaluate.py-quick-dev-baseline.md
@@ -3,9 +3,11 @@ id: TASK-608
 title: >-
   Resolve 4 unresolved ADR references flagged by evaluate.py --quick (dev
   baseline)
-status: To Do
-assignee: []
+status: In Progress
+assignee:
+  - '@claude'
 created_date: '2026-05-16 07:26'
+updated_date: '2026-05-17 10:03'
 labels:
   - ci
   - tech-debt

--- a/backlog/tasks/task-608 - Resolve-4-unresolved-ADR-references-flagged-by-evaluate.py-quick-dev-baseline.md
+++ b/backlog/tasks/task-608 - Resolve-4-unresolved-ADR-references-flagged-by-evaluate.py-quick-dev-baseline.md
@@ -7,7 +7,7 @@ status: In Progress
 assignee:
   - '@claude'
 created_date: '2026-05-16 07:26'
-updated_date: '2026-05-17 10:04'
+updated_date: '2026-05-17 10:06'
 labels:
   - ci
   - tech-debt
@@ -22,10 +22,10 @@ evaluate.py --quick fails the [ADR] References resolve check with '4 unresolved 
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 The 4 unresolved ADR references are enumerated with citing file:line and the ADR-NNN each points at
-- [ ] #2 Each reference is resolved (corrected citation, added/restored ADR, or fixed supersession link) with rationale recorded
-- [ ] #3 python evaluate.py --quick reports the [ADR] References resolve check as passing (0 unresolved out of total)
-- [ ] #4 python evaluate.py --quick shows no new failures vs the documented baseline (Health Score improves; Failed count for this check is 0)
+- [x] #1 The 4 unresolved ADR references are enumerated with citing file:line and the ADR-NNN each points at
+- [x] #2 Each reference is resolved (corrected citation, added/restored ADR, or fixed supersession link) with rationale recorded
+- [x] #3 python evaluate.py --quick reports the [ADR] References resolve check as passing (0 unresolved out of total)
+- [x] #4 python evaluate.py --quick shows no new failures vs the documented baseline (Health Score improves; Failed count for this check is 0)
 <!-- AC:END -->
 
 ## Implementation Plan
@@ -35,3 +35,24 @@ evaluate.py --quick fails the [ADR] References resolve check with '4 unresolved 
 2. Resolution path: none are dev-tree ADRs that should exist; fix check_adr_references_resolve to recognize reserved/skipped/unused numbers and cross-worktree (2.0.0/worktree/sibling/port) refs via the existing escape-hatch mechanism
 3. Run evaluate.py --quick to confirm 0 unresolved
 <!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Root cause: all 4 "unresolved" refs are legitimate, not ghost ADRs:
+- README.md:33 -> ADR-063 = documented intentionally-skipped/reserved no-op number
+- ADR-070:66 -> ADR-097, ADR-072:65/85 -> ADR-099 = cross-worktree refs to the parallel 2.0.0 line (independent ADR numbering; dev tree tops out at ADR-074)
+Resolution: extended check_adr_references_resolve with two tight escape hatches (reserved/skipped/unused/placeholder; 2.0.0/worktree/sibling) that require the cited line to itself name the reason, so the Phase 1B bare-ghost-citation class is still caught. evaluate.py --quick now 100%, Failed:0, "All 1230 ADR-NNN references resolve".
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Fixed check_adr_references_resolve in evaluate.py to stop flagging 4 false-positive ADR references that kept the dev push gate red.
+
+The 4 refs are legitimate: ADR-063 is the documented reserved no-op placeholder; ADR-097/ADR-099 are cross-worktree citations to the parallel 2.0.0 line which has independent ADR numbering. None are dev-tree ADRs that should exist.
+
+Change: added a tight excused_markers hatch (2.0.0|worktree|sibling|skipped|reserved|unused|placeholder, case-insensitive) alongside the existing forward-citation hatch. Both require the cited line to name the reason, preserving detection of the Phase 1B bare-ghost-ADR class (e.g. an unqualified ADR-077).
+
+Verification: python evaluate.py --quick -> Failed:0, Health 100% (was 91.7%); full run Health 96.1% (was 88.2%). No firmware touched (tooling-only, no version bump per policy).
+<!-- SECTION:FINAL_SUMMARY:END -->

--- a/backlog/tasks/task-617 - Fix-false-positive-and-stale-checks-in-evaluate.py.md
+++ b/backlog/tasks/task-617 - Fix-false-positive-and-stale-checks-in-evaluate.py.md
@@ -4,6 +4,7 @@ title: Fix false-positive and stale checks in evaluate.py
 status: To Do
 assignee: []
 created_date: '2026-05-17 10:03'
+updated_date: '2026-05-17 10:03'
 labels:
   - tooling
 dependencies: []
@@ -12,14 +13,13 @@ dependencies: []
 ## Description
 
 <!-- SECTION:DESCRIPTION:BEGIN -->
-evaluate.py reports 1 FAIL + 3 WARN that are bugs in the evaluator itself, not firmware defects. The ADR-reference FAIL also red-flags the documented origin/dev auto-push gate. Fix the four evaluator checks so the run reflects reality.
+evaluate.py reports 3 WARN-level checks that are bugs in the evaluator itself, not firmware defects (pragma-once header guard not recognized; stale sendMQTTheapdiag buffer-arithmetic check after refactor; BUILD.md/FLASH_GUIDE.md searched in wrong dir). The related ADR-reference FAIL is owned by TASK-608. Fix these 3 evaluator checks so the run reflects reality.
 <!-- SECTION:DESCRIPTION:END -->
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 check_adr_references_resolve skips reserved/skipped/unused ADR numbers and cross-worktree (2.0.0) references; the 4 known false positives no longer fail
-- [ ] #2 Header-guard check accepts '#pragma once' as a valid guard (mqtt_discovery_verify.h passes)
-- [ ] #3 JSON buffer-arithmetic check returns PASS (not WARN) when sendMQTTheapdiag has no fixed char[N] buffer
-- [ ] #4 Documentation check finds BUILD.md and FLASH_GUIDE.md in docs/guides/
-- [ ] #5 python evaluate.py shows 0 FAIL and these 4 items resolved; python evaluate.py --quick is green
+- [ ] #1 Header-guard check accepts '#pragma once' as a valid guard (mqtt_discovery_verify.h passes)
+- [ ] #2 JSON buffer-arithmetic check returns PASS (not WARN) when sendMQTTheapdiag has no fixed char[N] buffer
+- [ ] #3 Documentation check finds BUILD.md and FLASH_GUIDE.md in docs/guides/
+- [ ] #4 python evaluate.py shows 0 FAIL and these 4 items resolved; python evaluate.py --quick is green
 <!-- AC:END -->

--- a/backlog/tasks/task-617 - Fix-false-positive-and-stale-checks-in-evaluate.py.md
+++ b/backlog/tasks/task-617 - Fix-false-positive-and-stale-checks-in-evaluate.py.md
@@ -1,7 +1,7 @@
 ---
 id: TASK-617
 title: Fix false-positive and stale checks in evaluate.py
-status: In Progress
+status: Done
 assignee:
   - '@claude'
 created_date: '2026-05-17 10:03'

--- a/backlog/tasks/task-617 - Fix-false-positive-and-stale-checks-in-evaluate.py.md
+++ b/backlog/tasks/task-617 - Fix-false-positive-and-stale-checks-in-evaluate.py.md
@@ -5,7 +5,7 @@ status: In Progress
 assignee:
   - '@claude'
 created_date: '2026-05-17 10:03'
-updated_date: '2026-05-17 10:03'
+updated_date: '2026-05-17 10:04'
 labels:
   - tooling
 dependencies: []
@@ -22,5 +22,5 @@ evaluate.py reports 3 WARN-level checks that are bugs in the evaluator itself, n
 - [ ] #1 Header-guard check accepts '#pragma once' as a valid guard (mqtt_discovery_verify.h passes)
 - [ ] #2 JSON buffer-arithmetic check returns PASS (not WARN) when sendMQTTheapdiag has no fixed char[N] buffer
 - [ ] #3 Documentation check finds BUILD.md and FLASH_GUIDE.md in docs/guides/
-- [ ] #4 python evaluate.py shows 0 FAIL and these 4 items resolved; python evaluate.py --quick is green
+- [ ] #4 python evaluate.py: header-guard, buffer-arithmetic, and BUILD/FLASH doc checks all pass; no new failures introduced
 <!-- AC:END -->

--- a/backlog/tasks/task-617 - Fix-false-positive-and-stale-checks-in-evaluate.py.md
+++ b/backlog/tasks/task-617 - Fix-false-positive-and-stale-checks-in-evaluate.py.md
@@ -1,0 +1,25 @@
+---
+id: TASK-617
+title: Fix false-positive and stale checks in evaluate.py
+status: To Do
+assignee: []
+created_date: '2026-05-17 10:03'
+labels:
+  - tooling
+dependencies: []
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+evaluate.py reports 1 FAIL + 3 WARN that are bugs in the evaluator itself, not firmware defects. The ADR-reference FAIL also red-flags the documented origin/dev auto-push gate. Fix the four evaluator checks so the run reflects reality.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 check_adr_references_resolve skips reserved/skipped/unused ADR numbers and cross-worktree (2.0.0) references; the 4 known false positives no longer fail
+- [ ] #2 Header-guard check accepts '#pragma once' as a valid guard (mqtt_discovery_verify.h passes)
+- [ ] #3 JSON buffer-arithmetic check returns PASS (not WARN) when sendMQTTheapdiag has no fixed char[N] buffer
+- [ ] #4 Documentation check finds BUILD.md and FLASH_GUIDE.md in docs/guides/
+- [ ] #5 python evaluate.py shows 0 FAIL and these 4 items resolved; python evaluate.py --quick is green
+<!-- AC:END -->

--- a/backlog/tasks/task-617 - Fix-false-positive-and-stale-checks-in-evaluate.py.md
+++ b/backlog/tasks/task-617 - Fix-false-positive-and-stale-checks-in-evaluate.py.md
@@ -24,3 +24,12 @@ evaluate.py reports 3 WARN-level checks that are bugs in the evaluator itself, n
 - [ ] #3 Documentation check finds BUILD.md and FLASH_GUIDE.md in docs/guides/
 - [ ] #4 python evaluate.py: header-guard, buffer-arithmetic, and BUILD/FLASH doc checks all pass; no new failures introduced
 <!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Header-guard check (evaluate.py:148): also accept "#pragma once"
+2. Buffer-arithmetic check (evaluate.py:618): PASS when no char[N] buffer in body (refactored to per-stat publishStatU32)
+3. Doc check (evaluate.py:1271): add docs/guides/<doc> to search paths
+4. Run python evaluate.py to confirm all three pass, no regressions
+<!-- SECTION:PLAN:END -->

--- a/backlog/tasks/task-617 - Fix-false-positive-and-stale-checks-in-evaluate.py.md
+++ b/backlog/tasks/task-617 - Fix-false-positive-and-stale-checks-in-evaluate.py.md
@@ -5,7 +5,7 @@ status: In Progress
 assignee:
   - '@claude'
 created_date: '2026-05-17 10:03'
-updated_date: '2026-05-17 10:04'
+updated_date: '2026-05-17 10:06'
 labels:
   - tooling
 dependencies: []
@@ -19,10 +19,10 @@ evaluate.py reports 3 WARN-level checks that are bugs in the evaluator itself, n
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Header-guard check accepts '#pragma once' as a valid guard (mqtt_discovery_verify.h passes)
-- [ ] #2 JSON buffer-arithmetic check returns PASS (not WARN) when sendMQTTheapdiag has no fixed char[N] buffer
-- [ ] #3 Documentation check finds BUILD.md and FLASH_GUIDE.md in docs/guides/
-- [ ] #4 python evaluate.py: header-guard, buffer-arithmetic, and BUILD/FLASH doc checks all pass; no new failures introduced
+- [x] #1 Header-guard check accepts '#pragma once' as a valid guard (mqtt_discovery_verify.h passes)
+- [x] #2 JSON buffer-arithmetic check returns PASS (not WARN) when sendMQTTheapdiag has no fixed char[N] buffer
+- [x] #3 Documentation check finds BUILD.md and FLASH_GUIDE.md in docs/guides/
+- [x] #4 python evaluate.py: header-guard, buffer-arithmetic, and BUILD/FLASH doc checks all pass; no new failures introduced
 <!-- AC:END -->
 
 ## Implementation Plan
@@ -33,3 +33,25 @@ evaluate.py reports 3 WARN-level checks that are bugs in the evaluator itself, n
 3. Doc check (evaluate.py:1271): add docs/guides/<doc> to search paths
 4. Run python evaluate.py to confirm all three pass, no regressions
 <!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Three evaluator-self bugs fixed in evaluate.py:
+1. Header-guard check (line ~148): now accepts "#pragma once" OR #ifndef/#define. mqtt_discovery_verify.h (uses #pragma once) -> PASS.
+2. Buffer-arithmetic check (sendMQTTheapdiag): function was refactored to per-stat publishStatU32() calls with no fixed char[N] buffer, so no overflow surface. "no buffer" branch changed WARN -> PASS ("not applicable").
+3. Documentation check: BUILD.md/FLASH_GUIDE.md live in docs/guides/ per project layout; added docs/guides/ to candidate paths (root and docs/ kept for back-compat).
+All three now PASS; full evaluate.py Health 96.1% (was 88.2%), 0 FAIL.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Fixed 3 self-bugs in evaluate.py that produced false-positive/stale WARNs unrelated to firmware quality.
+
+- Header-guard check now recognizes "#pragma once" (modern guard) in addition to #ifndef/#define; mqtt_discovery_verify.h passes.
+- sendMQTTheapdiag buffer-arithmetic check: after the per-stat publishStatU32() refactor there is no fixed char[N] buffer and thus no overflow surface; the "no buffer found" branch now reports PASS (concern not applicable) instead of WARN.
+- Documentation check searches docs/guides/ (the documented home of operational guides) in addition to repo root and docs/; BUILD.md and FLASH_GUIDE.md now resolve.
+
+Verification: python evaluate.py -> 0 FAIL, Health 96.1% (was 88.2%); the three target checks report PASS. Tooling-only change (top-level evaluate.py), no firmware touched, no version bump per policy. The ADR-reference FAIL is owned by TASK-608 (fixed in the same commit).
+<!-- SECTION:FINAL_SUMMARY:END -->

--- a/backlog/tasks/task-617 - Fix-false-positive-and-stale-checks-in-evaluate.py.md
+++ b/backlog/tasks/task-617 - Fix-false-positive-and-stale-checks-in-evaluate.py.md
@@ -1,8 +1,9 @@
 ---
 id: TASK-617
 title: Fix false-positive and stale checks in evaluate.py
-status: To Do
-assignee: []
+status: In Progress
+assignee:
+  - '@claude'
 created_date: '2026-05-17 10:03'
 updated_date: '2026-05-17 10:03'
 labels:

--- a/evaluate.py
+++ b/evaluate.py
@@ -145,7 +145,7 @@ class WorkspaceEvaluator:
         for h_file in h_files:
             with open(h_file, 'r', encoding='utf-8', errors='ignore') as f:
                 content = f.read()
-                if '#ifndef' in content and '#define' in content:
+                if '#pragma once' in content or ('#ifndef' in content and '#define' in content):
                     self.add_result(EvaluationResult(
                         "Structure", f"Header guard: {h_file.name}", "PASS",
                         "Has header guards"
@@ -616,9 +616,13 @@ class WorkspaceEvaluator:
         # Extract buffer size: "char json[512];" or similar.
         buf_decl = re.search(r"\bchar\s+(\w+)\s*\[\s*(\d+)\s*\]", body)
         if not buf_decl:
+            # The function was refactored to per-stat publishStatU32() calls;
+            # with no fixed char[N] buffer there is no overflow surface, so the
+            # arithmetic concern is moot rather than unverified.
             self.add_result(EvaluationResult(
-                "Buffer", "sendMQTTheapdiag arithmetic", "WARN",
-                "No 'char X[N]' buffer declaration found in body"
+                "Buffer", "sendMQTTheapdiag arithmetic", "PASS",
+                "No fixed char[N] buffer in body — per-stat publish, "
+                "buffer-arithmetic check not applicable"
             ))
             return
         buf_name = buf_decl.group(1)
@@ -1010,9 +1014,22 @@ class WorkspaceEvaluator:
         class of finding (e.g. ADR-077/078/080 before TASK-355).
 
         Forward-citation escape hatch: if the ADR number appears on a line
-        (or within a 40-char window around the match) that contains one of
-        the markers ``future``, ``proposed``, or ``TBD`` (case-insensitive),
-        the reference is treated as a known forward citation and not failed.
+        that contains one of the markers ``future``, ``proposed``, or ``TBD``
+        (case-insensitive), the reference is treated as a known forward
+        citation and not failed.
+
+        Two further escape hatches cover legitimately-unresolvable numbers in
+        the dev tree:
+          * reserved/skipped numbers — a line documenting an intentionally
+            unused number (markers ``skipped``, ``reserved``, ``unused``,
+            ``placeholder``). ADR-063 is the documented no-op placeholder.
+          * cross-worktree references — a line that explicitly mentions the
+            parallel 2.0.0 line (``2.0.0``, ``worktree``, ``sibling``). The
+            2.0.0 worktree has its own independent ADR numbering, so refs
+            like ADR-097/ADR-099 do not resolve in the dev tree by design.
+        Both hatches are deliberately tight (the cited line must itself name
+        the reason) so the Phase 1B ghost-ADR class of finding — a bare,
+        unqualified ``ADR-077`` citation — is still caught.
         """
         print(f"\n{Colors.BOLD}{Colors.OKBLUE}=== ADR References Resolve ==={Colors.ENDC}")
 
@@ -1040,6 +1057,14 @@ class WorkspaceEvaluator:
 
         ref_re = re.compile(r"ADR-(\d{3})")
         forward_markers = re.compile(r"\b(future|proposed|TBD)\b", re.IGNORECASE)
+        # Tight hatches: the cited line must itself name the reason the number
+        # cannot resolve in the dev tree (reserved no-op number, or a ref to
+        # the parallel 2.0.0 worktree's independent numbering).
+        excused_markers = re.compile(
+            r"(2\.0\.0|\bworktree\b|\bsibling\b|\bskipped\b|"
+            r"\breserved\b|\bunused\b|\bplaceholder\b)",
+            re.IGNORECASE,
+        )
 
         unresolved: List[Tuple[str, int, str]] = []
         total_refs = 0
@@ -1052,8 +1077,10 @@ class WorkspaceEvaluator:
                             num = m.group(1)
                             if num in existing_nums:
                                 continue
-                            # Forward-citation escape.
+                            # Forward-citation / reserved / cross-worktree escapes.
                             if forward_markers.search(line):
+                                continue
+                            if excused_markers.search(line):
                                 continue
                             rel = target.relative_to(self.project_dir) if target.is_absolute() else target
                             unresolved.append((str(rel), lineno, f"ADR-{num}"))
@@ -1267,17 +1294,19 @@ class WorkspaceEvaluator:
         # Check for build documentation
         build_docs = ["BUILD.md", "FLASH_GUIDE.md"]
         for doc in build_docs:
-            doc_path = self.project_dir / doc
-            docs_path = self.project_dir / "docs" / doc
-            if doc_path.exists():
+            # Operational guides live under docs/guides/ per the project layout;
+            # also accept repo root and docs/ for backward compatibility.
+            candidates = [
+                (self.project_dir / doc, doc),
+                (self.project_dir / "docs" / doc, f"docs/{doc}"),
+                (self.project_dir / "docs" / "guides" / doc, f"docs/guides/{doc}"),
+            ]
+            found = next(((p, label) for p, label in candidates if p.exists()), None)
+            if found:
+                p, label = found
                 self.add_result(EvaluationResult(
                     "Documentation", doc, "PASS",
-                    f"Found ({doc_path.stat().st_size} bytes)"
-                ))
-            elif docs_path.exists():
-                self.add_result(EvaluationResult(
-                    "Documentation", doc, "PASS",
-                    f"Found (docs/{doc}, {docs_path.stat().st_size} bytes)"
+                    f"Found ({label}, {p.stat().st_size} bytes)"
                 ))
             else:
                 self.add_result(EvaluationResult(


### PR DESCRIPTION
## Summary

`evaluate.py` reported **1 FAIL + 3 WARN** that were bugs in the evaluator itself, not firmware defects. The ADR-reference FAIL also kept every dev PR's `Run evaluate.py --quick` gate red, masking genuinely new failures. This is a **tooling-only** change (top-level `evaluate.py`) — no firmware touched, no version bump per policy.

Tasks: **TASK-608** (ADR-reference FAIL) and **TASK-617** (the 3 evaluator-self WARNs).

## Changes

- **`check_adr_references_resolve`** — the 4 "unresolved" refs are all legitimate, not ghost ADRs:
  - `README.md:33 → ADR-063` — the documented intentionally-skipped/reserved no-op placeholder.
  - `ADR-070:66 → ADR-097`, `ADR-072:65/85 → ADR-099` — cross-worktree refs to the parallel 2.0.0 line, which has independent ADR numbering (dev tree tops out at ADR-074).
  - Added a **tight** escape hatch (`2.0.0|worktree|sibling|skipped|reserved|unused|placeholder`, case-insensitive) alongside the existing forward-citation hatch. Both require the cited line to itself name the reason, so the Phase 1B bare-ghost-ADR class (an unqualified `ADR-077`) is still caught.
- **Header-guard check** — now accepts `#pragma once` in addition to `#ifndef`/`#define` (`mqtt_discovery_verify.h`).
- **`sendMQTTheapdiag` buffer-arithmetic check** — the function was refactored to per-stat `publishStatU32()` calls with no fixed `char[N]` buffer, so there is no overflow surface; the "no buffer" branch now reports PASS (not applicable) instead of WARN.
- **Documentation check** — also searches `docs/guides/` (the documented home of operational guides) for `BUILD.md` / `FLASH_GUIDE.md`; repo root and `docs/` kept for back-compat.

## Test plan

- [x] `python evaluate.py --quick` → Failed: 0, Health 100% (was 91.7%)
- [x] `python evaluate.py` → 0 FAIL, Health 96.1% (was 88.2%); the 5 target checks all report PASS
- [x] `python -m py_compile evaluate.py` clean
- [x] Confirmed remaining WARNs are the chronic `String`-usage count (intentionally unchanged) only

Note: the `String` class usage WARN (21) is a long-standing informational count, acceptable per ADR-004 in setup/init/one-off contexts. Deliberately left as-is per the minimal-change-surface principle; a blanket refactor would be a separate, larger task.

https://claude.ai/code/session_015f3Y9bJDeaeNTDkpWfDkvu

---
_Generated by [Claude Code](https://claude.ai/code/session_015f3Y9bJDeaeNTDkpWfDkvu)_