### PR TITLE
Port stale evaluate.py checks to 2.0.0 (TASK-618)

### DIFF
--- a/backlog/tasks/task-618 - feat-2.0.0-port-TASK-617-—-stale-evaluate.py-checks-buffer-docs-path.md
+++ b/backlog/tasks/task-618 - feat-2.0.0-port-TASK-617-—-stale-evaluate.py-checks-buffer-docs-path.md
@@ -1,0 +1,59 @@
+---
+id: TASK-618
+title: 'feat-2.0.0: port TASK-617 — stale evaluate.py checks (buffer + docs path)'
+status: In Progress
+assignee:
+  - '@claude'
+created_date: '2026-05-17 10:23'
+updated_date: '2026-05-17 10:24'
+labels:
+  - tooling
+dependencies: []
+ordinal: 36000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Port the applicable subset of the dev evaluate.py tooling fixes (TASK-617) to the 2.0.0 line. Investigation showed only 2 of the 4 dev fixes apply here: the ADR-resolver false-positive (TASK-608) does not manifest on 2.0.0 (independent ADR inventory resolves), and the #pragma-once header-guard fix is already present in 2.0.0 evaluate.py. The 2.0.0 PROGMEM FAIL is a separate pre-existing firmware issue, explicitly out of scope.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Buffer-arithmetic check returns PASS (not WARN) when sendMQTTheapdiag has no fixed char[N] buffer — 2.0.0 firmware confirmed refactored to per-stat publishStatU32()
+- [x] #2 Documentation check finds BUILD.md and FLASH_GUIDE.md in docs/guides/ (present in 2.0.0 tree)
+- [x] #3 python evaluate.py on 2.0.0: the two target checks report PASS; no new failures vs the 90.8% baseline (pre-existing PROGMEM FAIL unchanged, out of scope)
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Buffer-arith no-buffer branch (evaluate.py ~1077): WARN -> PASS (per-stat publish, not applicable)
+2. Doc-check (evaluate.py ~2261): add docs/guides/<doc> candidate alongside root and docs/
+3. Run python evaluate.py on 2.0.0; confirm both target checks PASS and PROGMEM FAIL is the only remaining FAIL (pre-existing, out of scope)
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Investigation: of the 4 dev evaluate.py fixes (TASK-608 + TASK-617), only 2 apply to 2.0.0.
+- ADR-resolver false positive (TASK-608): does NOT manifest on 2.0.0 — its References-resolve check passes (independent ADR inventory; ADR-097/099 exist as files here).
+- #pragma-once header-guard fix: ALREADY present in 2.0.0 evaluate.py (line 606).
+- Buffer-arith no-buffer branch: ported WARN->PASS. 2.0.0 sendMQTTheapdiag confirmed refactored to per-stat publishStatU32() (no char[N] buffer).
+- Doc-check: ported docs/guides/ candidate. 2.0.0 has BUILD.md/FLASH_GUIDE.md under docs/guides/.
+Result: Passed 68->70, target WARNs cleared. Remaining FAIL is the pre-existing [PROGMEM] Flash string compliance (2 violations) — separate firmware issue, explicitly out of scope.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Ported the applicable subset of dev evaluate.py tooling fixes (TASK-617) to the 2.0.0 line.
+
+Only 2 of 4 dev fixes applied after per-branch verification (cross-worktree rule: confirm, do not assume parity):
+- sendMQTTheapdiag buffer-arithmetic check: no-buffer branch now PASS (not applicable) instead of WARN — 2.0.0 firmware confirmed using per-stat publishStatU32() with no fixed buffer.
+- Documentation check now also searches docs/guides/ for BUILD.md / FLASH_GUIDE.md (present there in the 2.0.0 tree).
+
+Not ported: ADR-resolver hatch (does not manifest on 2.0.0 — independent ADR inventory resolves) and #pragma-once header-guard (already fixed in 2.0.0 evaluate.py).
+
+Verification: python evaluate.py on 2.0.0 -> the 3 target checks PASS; Passed 68->70, no new failures. The single remaining FAIL ([PROGMEM] 2 violations) is pre-existing and unrelated — a separate firmware task, deliberately out of scope. Tooling-only change (top-level evaluate.py), no firmware touched, no version bump per policy.
+<!-- SECTION:FINAL_SUMMARY:END -->

--- a/evaluate.py
+++ b/evaluate.py
@@ -1075,9 +1075,13 @@ class WorkspaceEvaluator:
         # Extract buffer size: "char json[512];" or similar.
         buf_decl = re.search(r"\bchar\s+(\w+)\s*\[\s*(\d+)\s*\]", body)
         if not buf_decl:
+            # The function was refactored to per-stat publishStatU32() calls;
+            # with no fixed char[N] buffer there is no overflow surface, so the
+            # arithmetic concern is moot rather than unverified.
             self.add_result(EvaluationResult(
-                "Buffer", "sendMQTTheapdiag arithmetic", "WARN",
-                "No 'char X[N]' buffer declaration found in body"
+                "Buffer", "sendMQTTheapdiag arithmetic", "PASS",
+                "No fixed char[N] buffer in body — per-stat publish, "
+                "buffer-arithmetic check not applicable"
             ))
             return
         buf_name = buf_decl.group(1)
@@ -2260,17 +2264,19 @@ class WorkspaceEvaluator:
         # Check for build documentation
         build_docs = ["BUILD.md", "FLASH_GUIDE.md"]
         for doc in build_docs:
-            doc_path = self.project_dir / doc
-            docs_path = self.project_dir / "docs" / doc
-            if doc_path.exists():
+            # Operational guides live under docs/guides/ per the project layout;
+            # also accept repo root and docs/ for backward compatibility.
+            candidates = [
+                (self.project_dir / doc, doc),
+                (self.project_dir / "docs" / doc, f"docs/{doc}"),
+                (self.project_dir / "docs" / "guides" / doc, f"docs/guides/{doc}"),
+            ]
+            found = next(((p, label) for p, label in candidates if p.exists()), None)
+            if found:
+                p, label = found
                 self.add_result(EvaluationResult(
                     "Documentation", doc, "PASS",
-                    f"Found ({doc_path.stat().st_size} bytes)"
-                ))
-            elif docs_path.exists():
-                self.add_result(EvaluationResult(
-                    "Documentation", doc, "PASS",
-                    f"Found (docs/{doc}, {docs_path.stat().st_size} bytes)"
+                    f"Found ({label}, {p.stat().st_size} bytes)"
                 ))
             else:
                 self.add_result(EvaluationResult(


### PR DESCRIPTION
## Summary

Ports the applicable subset of the dev `evaluate.py` tooling fixes (dev PR #592 / TASK-617) to the 2.0.0 line. **Tooling-only** (top-level `evaluate.py`) — no firmware touched, no version bump per policy. Task: **TASK-618**.

Per the cross-worktree rule ("confirm, do not assume parity"), each dev fix was verified against the 2.0.0 tree first. Only **2 of the 4** dev fixes apply here:

| Dev fix | 2.0.0 status | Action |
|---|---|---|
| ADR-reference resolver hatch | Does **not** manifest — 2.0.0's independent ADR inventory resolves ADR-097/099 | Not ported |
| `#pragma once` header guard | **Already present** in 2.0.0 `evaluate.py` (line 606) | Not ported |
| `sendMQTTheapdiag` buffer arithmetic | Present (2.0.0 firmware confirmed refactored to per-stat `publishStatU32()`, no fixed buffer) | **Ported** |
| `docs/guides/` doc-check path | Present (BUILD.md/FLASH_GUIDE.md live in `docs/guides/`) | **Ported** |

## Changes

- **`sendMQTTheapdiag` buffer-arithmetic check** — the no-buffer branch now reports PASS (concern not applicable) instead of WARN, since the refactored body has no fixed `char[N]` overflow surface.
- **Documentation check** — also searches `docs/guides/` for `BUILD.md` / `FLASH_GUIDE.md`; repo root and `docs/` retained for back-compat.

## Test plan

- [x] `python -m py_compile evaluate.py` clean
- [x] `python evaluate.py` on 2.0.0 → the 3 target checks (`sendMQTTheapdiag arithmetic`, `BUILD.md`, `FLASH_GUIDE.md`) all PASS
- [x] Passed 68 → 70, no new failures vs the 90.8% baseline

## Out of scope

The 2.0.0 tree has a **pre-existing, unrelated** `[PROGMEM] Flash string compliance` FAIL (2 violations) — a genuine firmware issue, not part of this tooling port. Reported separately for triage; not addressed here.

> Note: committed unsigned (user-authorized) — the managed commit-signing server in this session is scoped to the dev session branch and rejects the 2.0.0 branch.

https://claude.ai/code/session_015f3Y9bJDeaeNTDkpWfDkvu

---
_Generated by [Claude Code](https://claude.ai/code/session_015f3Y9bJDeaeNTDkpWfDkvu)_