### PR TITLE
ci(beta-prerelease): create tag from ref in workflow_dispatch

### DIFF
--- a/.github/workflows/beta-prerelease.yml
+++ b/.github/workflows/beta-prerelease.yml
@@ -37,8 +37,13 @@ on:
   workflow_dispatch:
     inputs:
       tag:
-        description: 'Existing prerelease tag to (re)publish (e.g. v1.6.0-beta.4)'
+        description: 'Prerelease tag to (re)publish (e.g. v1.6.0-beta.4). Created at `ref` if missing.'
         required: true
+        type: string
+      ref:
+        description: 'Branch or commit to tag if `tag` does not yet exist on origin (default: dev). Ignored when the tag already exists.'
+        required: false
+        default: 'dev'
         type: string
 
 jobs:
@@ -49,6 +54,23 @@ jobs:
       contents: write   # required to create release and upload assets
 
     steps:
+      - name: Create tag if missing (workflow_dispatch only)
+        if: github.event_name == 'workflow_dispatch'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          TAG="${{ inputs.tag }}"
+          REF="${{ inputs.ref }}"
+          if gh api "repos/${{ github.repository }}/git/refs/tags/${TAG}" >/dev/null 2>&1; then
+            echo "Tag ${TAG} already exists on origin, reusing it."
+          else
+            SHA=$(gh api "repos/${{ github.repository }}/commits/${REF}" --jq '.sha')
+            [ -n "${SHA}" ] || { echo "ERROR: could not resolve ref '${REF}' to a commit SHA"; exit 1; }
+            echo "Creating tag ${TAG} at ${REF} (${SHA})"
+            gh api -X POST "repos/${{ github.repository }}/git/refs" \
+              -f ref="refs/tags/${TAG}" -f sha="${SHA}"
+          fi
+
       - name: Resolve tag name
         id: tag
         run: |


### PR DESCRIPTION
## Summary

One-shot mobile path for publishing a beta prerelease. After this merges, `v1.6.0-beta.6` (and any future beta) can be published end-to-end from the GitHub Actions tab on mobile, with no local git required.

## Why this exists

The `beta-prerelease.yml` workflow currently fires on `push: tags` or on `workflow_dispatch` with an **existing** tag. Pushing a tag is the maintainer's local action. From a Claude Code web session the container's git proxy returns `HTTP 403` on tag pushes (deliberate policy), and from a mobile GitHub UI there is no first-class "create tag" affordance either. The result: even when `dev` is ready for a beta cut, the publish stalls until the maintainer can sit at a workstation.

## What changes

`workflow_dispatch` gets a second input and one new step.

- **New input `ref`** (default `dev`): names the branch or commit to tag if the supplied `tag` does not yet exist on origin. Ignored when the tag already exists, so the existing "re-publish a stuck draft" use case is untouched.
- **New step "Create tag if missing"**: resolves `ref` to a commit SHA via `GET repos/.../commits/<ref>` and POSTs `refs/tags/<tag>` via `POST repos/.../git/refs` using `GITHUB_TOKEN`. Idempotent: if the tag is already on origin, the step prints "reusing it" and continues. The existing `Resolve tag name` and `Checkout code at tag` steps then operate against the freshly created (or pre-existing) tag without modification.

Tag-push trigger (`on: push: tags`) is unchanged. The new path activates only on `workflow_dispatch`.

## Mobile flow after merge

To publish `v1.6.0-beta.6`:

1. Open https://github.com/rvdbreemen/OTGW-firmware/actions/workflows/beta-prerelease.yml
2. Tap **Run workflow** -> branch `dev`, `tag` = `v1.6.0-beta.6`, `ref` = `dev` (default).
3. Workflow creates the tag at `dev`'s tip (`3a10a60`, the merge of #608), builds firmware + filesystem, generates `SHA256SUMS` and the flash-bundle zip, and publishes the GitHub prerelease with all six assets attached.

Tag, release, and assets all exist after the single run.

## Why this is safe

- `GITHUB_TOKEN` with `contents: write` (already declared on the job) is the standard permission for creating refs. No new secrets, no new scopes.
- Tags created by `GITHUB_TOKEN` do not trigger downstream workflows that listen on `push: tags` (documented anti-recursion), so the new step cannot accidentally re-fire this same workflow.
- The step runs only on `workflow_dispatch`, so the existing tag-push path (the maintainer's local `git push origin v<tag>` flow) is unaffected.
- Existing tags are reused, not overwritten. The step never POSTs an update or DELETE to a ref.

## Test plan

- [ ] Merge to `dev`
- [ ] From mobile: Actions -> Beta prerelease publish -> Run workflow, `tag`=`v1.6.0-beta.6`, `ref`=`dev`
- [ ] Confirm the workflow run logs show "Creating tag v1.6.0-beta.6 at dev (<sha>)" followed by a successful release publish
- [ ] Verify the release at https://github.com/rvdbreemen/OTGW-firmware/releases/tag/v1.6.0-beta.6 carries `.ino.bin`, `.littlefs.bin`, `SHA256SUMS`, `flash_otgw.sh`, `flash_otgw.bat`, and the flash-bundle zip
- [ ] Re-run with the same `tag` to confirm idempotency (step should print "reusing it" and republish the draft)


---
_Generated by [Claude Code](https://claude.ai/code/session_01Ker27pxBwcZDVPcsjJg7Wy)_