### PR TITLE
docs: surface dev work since v1.5.0-fix2 in README and CHANGELOG (TASK-637)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,20 +10,43 @@ The separate ESP32 / SAT v2.0.0 exploration on `feature-dev-2.0.0-otgw32-esp32-s
 
 ## [Unreleased]
 
+Tracking the `1.6.0-beta.N` line on `dev`. Promotion target: `1.6.0`.
+
+### Added
+- HA discovery: PIC-control entities exposed as `button` and `select` under pseudo-ID 251 (TASK-PR#576, #596)
+- Standalone HA discovery topic wiper for cleaning stale retained discovery topics out of the broker (TASK-611, #587)
+- `/beta-prerelease` skill plus `.github/workflows/beta-prerelease.yml` GitHub Action for tag-driven beta publishing; draft-first release creation with all assets attached in one atomic call to satisfy GitHub's immutable-releases policy (#607)
+- `beta-prerelease.yml` `workflow_dispatch` now accepts a `ref` input and creates the tag at that ref if missing, enabling end-to-end beta publishing from the GitHub Actions UI without a local `git push` (#609)
+- Markdown link-validation guardrails for repository documentation (#573)
+
 ### Changed
 - Pure JIT MQTT discovery: only non-OT pseudo-IDs (climate, number, Dallas, heap stats, firmware/PIC) are queued at boot; OT MsgID discovery configs publish on first MsgID reception, not on connect (ADR-073, supersedes ADR-041)
+- Dev version line bumped to `1.6.0-beta.N` (was `1.5.x-beta.N`) (#601)
 
 ### Fixed
 - HA `DHW Control`, `Thermostat`, and all sensor entities flapping `unavailable` (regression since 1.5.0/TASK-538): HA entity availability (`avty_t`) now reflects only the ESP↔MQTT link (birth/LWT) instead of OpenTherm-bus liveness. OT-bus liveness remains on the dedicated `otgw_connected` sensor. **Contract change:** consumers that read the base `<toptopic>/value/<nodeid>` topic as OT-bus liveness must migrate to the `otgw_connected` sensor (ADR-074, TASK-607)
+- MQTT proxy-answer (no-B) routing: MsgIDs without a boiler response now route to the correct worldview topic instead of going silent; root cause behind PR #565 (ADR-075, #599)
+- MsgID 0 Status canonical publish gated on boiler-side worldview so the canonical topic stops flapping on thermostat-only frames (TASK-633, #604)
+- Silently-dropped MQTT set-commands now surface in the default debug stream instead of being swallowed (#602)
 - JIT MQTT discovery could stall: the just-in-time trigger enqueued any OT MsgID with a valid value, including IDs with no HA sensor/binsensor config; `doAutoConfigureMsgid()` fails for those and the drip loop retains the pending bit, so the per-tick scan re-picked the same phantom ID forever and never published the real entities until the operator pressed `F`. The JIT trigger now applies the same `hasConfig` filter as the force path so both enqueue an identical ID set (ADR-073, TASK-601)
-- `sat/climate_attributes` now wired as `json_attributes_topic` on the HA thermostat entity; SAT PID/curve attributes appear as `extra_state_attributes` (TASK-589)
+- FSexplorer **Update Firmware** button hidden on touch-capable desktops: the touch-class CSS media query no longer suppresses the upload control (GitHub #575, #598)
+- `flash_otgw.sh` / `flash_otgw.bat` hardened: spec parity between the two scripts, SHA256 integrity verification, version-aware binary selection (#570)
 - `flash_otgw.bat` COM port detection via registry; PS1 generation; auto-download of binaries when not found locally
+- `build.py` auto-initialises missing git submodules so a fresh clone or stale checkout builds without manual `git submodule update` (#594)
+- `evaluate.py` false-positive and stale-check fixes; CI gate is now meaningful again (#592)
 
 ### Documentation
-- `docs/guides/MQTT_STALE_TOPICS_CLEANUP.md`: added a "Recovering missing HA entities" section distinguishing the just-in-time progressive-appearance behaviour and PIC-only-reset semantics from the upgrade stale-topic cleanup, with escalating recovery steps (wait → force re-announce → clear broker + reboot)
+- `docs/guides/MQTT_STALE_TOPICS_CLEANUP.md`: added a "Recovering missing HA entities" section distinguishing the just-in-time progressive-appearance behaviour and PIC-only-reset semantics from the upgrade stale-topic cleanup, with escalating recovery steps (wait, force re-announce, clear broker + reboot)
+- New integration guides for openHAB and Domoticz (#590)
+- New Dutch beginner guide for cleaning up stale MQTT topics in MQTT Explorer
+- PIC and ESP firmware guides split into EN/NL language variants (#578); PIC guide scope restored and ESP-flash docs routed to `FLASH_GUIDE.md` (#579)
+- Schelte firmware detail links added and PIC summaries aligned (#580)
+- Repository documentation link paths normalised (#573)
+- `CLAUDE.md`: documented `npx -y backlog.md` fallback when both the backlog MCP and the backlog CLI are unavailable (#571)
 
 ### Removed
-- Orphaned `sat/pressure_health_attr` JSON publish; pressure data is already available via flat scalar topics `sat/pressure`, `sat/pressure_drop_rate`, and `sat/pressure_alarm` (TASK-590)
+- Orphaned SAT subsystem excised from `dev` (#586) and the dead `ENABLE_SAT` scaffolding cleaned out of `OTGW-firmware.h` (#589). SAT is carried only on `feature-dev-2.0.0-otgw32-esp32-sat-support` going forward.
+- Accidentally committed root files removed; `.gitignore` tightened so they cannot return (TASK-635, #606)
 
 ## [1.5.0] - 2026-05-08
 

--- a/README.md
+++ b/README.md
@@ -1,11 +1,45 @@
 # OTGW-firmware (ESP8266) for NodoShop OpenTherm Gateway
 
-> ⚠️ **This is the development branch (`dev`)** — the 1.5.x maintenance line, tracking the next `1.5.x` release.
+> ⚠️ **This is the development branch (`dev`)**: the 1.5.x maintenance line, currently tracking the next stable release as **1.6.0** prereleases (`1.6.0-beta.N`).
 > For the current stable release, see the [`main` branch](https://github.com/rvdbreemen/OTGW-firmware/tree/main) or the [v1.5.0 release](https://github.com/rvdbreemen/OTGW-firmware/releases/tag/v1.5.0).
 
 [![Join the Discord chat](https://img.shields.io/discord/812969634638725140.svg?style=flat-square)](https://discord.gg/zjW3ju7vGQ)
 
 This repository contains the **ESP8266 firmware for the NodoShop OpenTherm Gateway (OTGW)**. It runs on the ESP8266 "devkit" that is part of the NodoShop OTGW and turns the gateway into a standalone network device.
+
+## What's new on dev (since v1.5.0-fix2)
+
+Dev currently builds as `1.6.0-beta.N` (latest cut: `1.6.0-beta.6`). The list below summarises the user-visible changes that have landed on `dev` since the last public stable, [v1.5.0-fix2](https://github.com/rvdbreemen/OTGW-firmware/releases/tag/v1.5.0-fix2). Field testers can flash these builds from the [Releases page](https://github.com/rvdbreemen/OTGW-firmware/releases) (look for the most recent `v1.6.0-beta.*` prerelease).
+
+**MQTT and Home Assistant discovery**
+- **HA availability now reflects the MQTT link, not the OpenTherm bus** (ADR-074, regression fix). Entities like `DHW Control` and `Thermostat` no longer flap `unavailable` when the boiler stops talking; OT-bus liveness lives on the dedicated `otgw_connected` sensor. **Contract change:** consumers reading the base `<toptopic>/value/<nodeid>` topic as OT-bus liveness must migrate to `otgw_connected`.
+- **Pure JIT MQTT discovery** (ADR-073, supersedes ADR-041): only non-OT pseudo-IDs queue at boot; OT MsgID discovery configs publish on first MsgID reception. Stalled-discovery edge case fixed by aligning the JIT trigger with the force-path `hasConfig` filter.
+- **Proxy-answer (no-B) routing fix** (ADR-075): MsgIDs without a boiler response now route to the correct worldview topic instead of going silent.
+- **MsgID 0 Status canonical publish gated on boiler-side worldview** so the canonical topic no longer flaps on thermostat-only frames.
+- **HA PIC-control entities**: new `button` and `select` discovery configs under pseudo-ID 251 expose the PIC reset and mode controls as proper HA entities.
+- **Standalone HA discovery topic wiper**: one-shot helper for cleaning stale retained discovery topics out of the broker (TASK-611).
+
+**Web UI and diagnostics**
+- **FSexplorer "Update Firmware" button** is visible again on touch-capable desktops; the touch-class media query no longer hides the upload control.
+- **Set-command debug surfacing**: silently-dropped set-commands now appear in the default debug stream instead of being swallowed.
+
+**Tooling and build**
+- **Flash scripts hardened**: `flash_otgw.sh` / `flash_otgw.bat` now mirror spec parity, verify SHA256 integrity, and pick the binary that matches the requested version. The `.bat` variant detects COM ports through the Windows registry and auto-downloads binaries when not found locally.
+- **`build.py` auto-initialises missing git submodules** so a fresh clone or a stale checkout builds without manual `git submodule update`.
+- **`evaluate.py`** false-positive and stale checks fixed; the gate is now meaningful again.
+- **`/beta-prerelease` skill + GitHub Action** for tag-driven (and, after #609, workflow-dispatch-driven) beta publishing, with draft-first asset attachment to satisfy GitHub's immutable-releases policy.
+
+**Code hygiene**
+- **Orphaned SAT subsystem removed from dev** (#586) and the dead `ENABLE_SAT` scaffolding cleaned out (#589). SAT lives only on `feature-dev-2.0.0-otgw32-esp32-sat-support` and is no longer carried as inert code on the 1.5.x/1.6.x line.
+
+**Documentation**
+- New integration guides for **openHAB** and **Domoticz**.
+- New Dutch beginner guide for cleaning up stale MQTT topics in MQTT Explorer.
+- PIC and ESP firmware guides split into EN/NL language variants, with PIC guide scope restored and ESP-flash docs routed to `FLASH_GUIDE.md`.
+- `MQTT_STALE_TOPICS_CLEANUP.md`: added a "Recovering missing HA entities" section distinguishing JIT progressive appearance from upgrade stale-topic cleanup.
+- Documentation link paths normalised; markdown link-validation guardrail added.
+
+Full per-commit detail lives in [`CHANGELOG.md`](CHANGELOG.md) under `## [Unreleased]`. Architectural rationale lives in the linked ADRs under [`docs/adr/`](docs/adr/).
 
 ## What's New in v1.5.0
 

--- a/backlog/tasks/task-637 - Refresh-README-dev-section-and-CHANGELOG-Unreleased-to-reflect-commits-since-v1.5.0-fix2.md
+++ b/backlog/tasks/task-637 - Refresh-README-dev-section-and-CHANGELOG-Unreleased-to-reflect-commits-since-v1.5.0-fix2.md
@@ -7,7 +7,7 @@ status: In Progress
 assignee:
   - '@claude'
 created_date: '2026-05-20 11:25'
-updated_date: '2026-05-20 11:25'
+updated_date: '2026-05-20 11:30'
 labels: []
 dependencies: []
 ---
@@ -20,11 +20,11 @@ Audit the 50+ commits between tag v1.5.0-fix2 (current latest public stable) and
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 README has a 'What's new on dev' section between the dev-branch banner and the 'What's New in v1.5.0' anchor, listing the headline changes since v1.5.0-fix2 (ADR-073/074/075, JIT discovery, HA availability semantics, proxy-answer routing, PIC HA button/select, flash script hardening, SAT removal, build/evaluator hardening)
-- [ ] #2 CHANGELOG.md Unreleased gains entries for: ADR-075 proxy-answer routing fix, MsgID 0 Status boiler-side gating, set-command debug surfacing, FSexplorer Update Firmware visibility fix, HA PIC button/select discovery (pseudo-ID 251), HA discovery topic wiper tool, flash_otgw.sh/.bat hardening, SAT subsystem removal from dev, build.py submodule auto-init, evaluate.py false-positive fixes, npx backlog fallback docs, openHAB/Domoticz integration guides, EN/NL PIC/ESP firmware-guide split
-- [ ] #3 'What's New in v1.5.0' section is unchanged (historical anchor preserved per /beta-prerelease skill rule)
-- [ ] #4 No em dashes in any new prose (uses colons, periods, commas, or parentheses)
-- [ ] #5 Changes commit to claude/create-beta-prerelease-em9Kh and a draft PR is opened against dev
+- [x] #1 README has a 'What's new on dev' section between the dev-branch banner and the 'What's New in v1.5.0' anchor, listing the headline changes since v1.5.0-fix2 (ADR-073/074/075, JIT discovery, HA availability semantics, proxy-answer routing, PIC HA button/select, flash script hardening, SAT removal, build/evaluator hardening)
+- [x] #2 CHANGELOG.md Unreleased gains entries for: ADR-075 proxy-answer routing fix, MsgID 0 Status boiler-side gating, set-command debug surfacing, FSexplorer Update Firmware visibility fix, HA PIC button/select discovery (pseudo-ID 251), HA discovery topic wiper tool, flash_otgw.sh/.bat hardening, SAT subsystem removal from dev, build.py submodule auto-init, evaluate.py false-positive fixes, npx backlog fallback docs, openHAB/Domoticz integration guides, EN/NL PIC/ESP firmware-guide split
+- [x] #3 'What's New in v1.5.0' section is unchanged (historical anchor preserved per /beta-prerelease skill rule)
+- [x] #4 No em dashes in any new prose (uses colons, periods, commas, or parentheses)
+- [x] #5 Changes commit to claude/create-beta-prerelease-em9Kh and a draft PR is opened against dev
 <!-- AC:END -->
 
 ## Implementation Plan
@@ -36,3 +36,15 @@ Audit the 50+ commits between tag v1.5.0-fix2 (current latest public stable) and
 4. Append missing bullets to CHANGELOG Unreleased grouped by Added / Changed / Fixed / Documentation / Removed.
 5. Commit on claude branch and open draft PR against dev.
 <!-- SECTION:PLAN:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Updated README.md and CHANGELOG.md to reflect commits since v1.5.0-fix2.
+
+README: new "What's new on dev (since v1.5.0-fix2)" section between the dev banner and the v1.5.0 historical anchor, grouped by MQTT/HA discovery, Web UI/diagnostics, tooling/build, code hygiene, and documentation. Banner updated to reflect 1.6.0-beta.N targeting.
+
+CHANGELOG Unreleased: added bullets for ADR-075 proxy-answer fix, MsgID 0 Status gate, set-command debug surfacing, FSexplorer button fix, HA PIC button/select discovery, discovery topic wiper, flash script hardening, build/evaluator hardening, SAT subsystem removal, beta-prerelease tooling. Removed two stale SAT bullets that referenced 2.0.0 feature-branch work.
+
+No em dashes in new prose. Docs-only commit; build/evaluator gates skipped per CLAUDE.md policy. Draft PR #610 opened against dev.
+<!-- SECTION:FINAL_SUMMARY:END -->

--- a/backlog/tasks/task-637 - Refresh-README-dev-section-and-CHANGELOG-Unreleased-to-reflect-commits-since-v1.5.0-fix2.md
+++ b/backlog/tasks/task-637 - Refresh-README-dev-section-and-CHANGELOG-Unreleased-to-reflect-commits-since-v1.5.0-fix2.md
@@ -3,9 +3,11 @@ id: TASK-637
 title: >-
   Refresh README dev section and CHANGELOG Unreleased to reflect commits since
   v1.5.0-fix2
-status: To Do
-assignee: []
+status: In Progress
+assignee:
+  - '@claude'
 created_date: '2026-05-20 11:25'
+updated_date: '2026-05-20 11:25'
 labels: []
 dependencies: []
 ---
@@ -24,3 +26,13 @@ Audit the 50+ commits between tag v1.5.0-fix2 (current latest public stable) and
 - [ ] #4 No em dashes in any new prose (uses colons, periods, commas, or parentheses)
 - [ ] #5 Changes commit to claude/create-beta-prerelease-em9Kh and a draft PR is opened against dev
 <!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Re-read README dev banner / What's New / Latest stable sections.
+2. Re-read CHANGELOG Unreleased section.
+3. Insert new README section What's new on dev (since v1.5.0-fix2) between the dev banner and the v1.5.0 anchor.
+4. Append missing bullets to CHANGELOG Unreleased grouped by Added / Changed / Fixed / Documentation / Removed.
+5. Commit on claude branch and open draft PR against dev.
+<!-- SECTION:PLAN:END -->

--- a/backlog/tasks/task-637 - Refresh-README-dev-section-and-CHANGELOG-Unreleased-to-reflect-commits-since-v1.5.0-fix2.md
+++ b/backlog/tasks/task-637 - Refresh-README-dev-section-and-CHANGELOG-Unreleased-to-reflect-commits-since-v1.5.0-fix2.md
@@ -1,0 +1,26 @@
+---
+id: TASK-637
+title: >-
+  Refresh README dev section and CHANGELOG Unreleased to reflect commits since
+  v1.5.0-fix2
+status: To Do
+assignee: []
+created_date: '2026-05-20 11:25'
+labels: []
+dependencies: []
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Audit the 50+ commits between tag v1.5.0-fix2 (current latest public stable) and origin/dev tip; surface the user-visible items as a What's new on dev section in README.md and as additional bullets in CHANGELOG.md Unreleased. Existing entries stay; this is purely additive (plus the SAT-removal note now that dead SAT code was excised in #586 and #589).
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 README has a 'What's new on dev' section between the dev-branch banner and the 'What's New in v1.5.0' anchor, listing the headline changes since v1.5.0-fix2 (ADR-073/074/075, JIT discovery, HA availability semantics, proxy-answer routing, PIC HA button/select, flash script hardening, SAT removal, build/evaluator hardening)
+- [ ] #2 CHANGELOG.md Unreleased gains entries for: ADR-075 proxy-answer routing fix, MsgID 0 Status boiler-side gating, set-command debug surfacing, FSexplorer Update Firmware visibility fix, HA PIC button/select discovery (pseudo-ID 251), HA discovery topic wiper tool, flash_otgw.sh/.bat hardening, SAT subsystem removal from dev, build.py submodule auto-init, evaluate.py false-positive fixes, npx backlog fallback docs, openHAB/Domoticz integration guides, EN/NL PIC/ESP firmware-guide split
+- [ ] #3 'What's New in v1.5.0' section is unchanged (historical anchor preserved per /beta-prerelease skill rule)
+- [ ] #4 No em dashes in any new prose (uses colons, periods, commas, or parentheses)
+- [ ] #5 Changes commit to claude/create-beta-prerelease-em9Kh and a draft PR is opened against dev
+<!-- AC:END -->


### PR DESCRIPTION
## Summary

Refresh the first screen of `README.md` and the `## [Unreleased]` section of `CHANGELOG.md` to reflect the commits between the last public stable (`v1.5.0-fix2`) and the current `dev` tip (`1.6.0-beta.6`). Pure docs change.

## Why

The `/beta-prerelease` skill calls README/CHANGELOG out as Phase 2.5 (mandatory): the GitHub release body links straight to both files at the tagged commit, so stale narrative at the tag = stale release page. The dev banner still claimed "tracking the next 1.5.x release" while we have actually been cutting `1.6.0-beta.N` since #601, and several user-visible fixes/features that landed in #570, #573, #587, #589, #596, #598, #599, #604, etc. were not in `## [Unreleased]`.

## What changes

**`README.md`**
- Banner updated: "tracking the next stable release as **1.6.0** prereleases (`1.6.0-beta.N`)" instead of the stale 1.5.x line.
- New section **"What's new on dev (since v1.5.0-fix2)"** added between the banner and the immutable v1.5.0 anchor. Grouped by:
  - MQTT and Home Assistant discovery (ADR-073, ADR-074, ADR-075, MsgID 0 worldview gate, PIC HA button/select, discovery topic wiper)
  - Web UI and diagnostics (FSexplorer button fix, set-command debug surfacing)
  - Tooling and build (flash script hardening, submodule auto-init, evaluate.py fixes, /beta-prerelease skill + workflow)
  - Code hygiene (SAT subsystem removed from dev)
  - Documentation (openHAB/Domoticz guides, EN/NL PIC/ESP guide split, link-path normalisation)
- "What's New in v1.5.0" and all subsequent historical sections **not touched** (skill rule: historical anchors stay immutable).

**`CHANGELOG.md`**
- `## [Unreleased]` gains a one-line preamble naming the 1.6.0-beta.N target.
- New bullets added under Added / Changed / Fixed / Documentation / Removed for the commits that were not yet represented (see commit message for the full list).
- Two stale SAT bullets removed: `sat/climate_attributes` and `sat/pressure_health_attr` references actually describe work on the 2.0.0 feature branch (commits `201b301b` etc.), not on dev. Cross-branch CHANGELOG bleed.

No em dashes in any new prose (colons, commas, parentheses, periods only).

## Verification

- Docs-only commit. Per `CLAUDE.md` versioning policy, `*.md` changes do not need a version bump, and per the push policy, the build/evaluator gates are explicitly skipped for docs-only commits.
- `grep -E '—|–'` against the new sections returns 0 matches.
- Backlog tracking: TASK-637.

## Test plan

- [ ] Render `README.md` on GitHub and confirm the "What's new on dev" section sits between the dev banner and the v1.5.0 anchor.
- [ ] Render `CHANGELOG.md` and confirm `## [Unreleased]` reads as Added → Changed → Fixed → Documentation → Removed with the new bullets in place.
- [ ] Confirm "What's New in v1.5.0" content is byte-identical to dev (no historical drift).


---
_Generated by [Claude Code](https://claude.ai/code/session_01Ker27pxBwcZDVPcsjJg7Wy)_