### PR TITLE
feat(release): inline 'since last public' digest in beta release body + gate README/CHANGELOG check first (TASK-639)

### DIFF
--- a/.claude/skills/beta-prerelease/SKILL.md
+++ b/.claude/skills/beta-prerelease/SKILL.md
@@ -36,8 +36,8 @@ Do NOT use this skill for:
 | Target branch | `dev` then merge to `main` | `dev` only |
 | Bumps `_SEMVER_CORE` | yes (1.5.0 -> 1.6.0) | no |
 | Bumps `_VERSION_PRERELEASE` | sets to `beta.0` after release | increments by 1 |
-| Edits `README.md` | yes (What's New section) | no |
-| Generates `RELEASE_NOTES_*.md` | yes | no |
+| Edits `README.md` | yes (What's New section) | yes (Phase 1 staleness gate refreshes the "What's new on dev" section when needed) |
+| Maintains `RELEASE_NOTES_*.md` | yes (per stable: `RELEASE_NOTES_<version>.md`) | yes (per beta line: `RELEASE_NOTES_<base>-beta.md`); CI inlines the digest above the `<!-- digest:end -->` sentinel into the release body |
 | GitHub release marked prerelease | no | yes |
 | Discord channels | `#nederlandse-ondersteuning`, `#english-support` | `#beta-testing` |
 | Frequency | once per minor cycle | many times per minor cycle |
@@ -51,7 +51,7 @@ Do NOT use this skill for:
 
 ## Process
 
-Nine phases. Only **one mandatory checkpoint** (the Discord announcement at the end). All other phases proceed automatically unless something unexpected happens.
+Ten phases. The narrative-refresh gate (Phase 1) runs **before** the version bump so a stale README or CHANGELOG cannot ride out under a fresh tag. Only **one mandatory checkpoint** (the Discord announcement at the end). All other phases proceed automatically unless the staleness check fires or something unexpected happens.
 
 ### Phase 0: Prepare - clean state on dev
 
@@ -64,16 +64,49 @@ Nine phases. Only **one mandatory checkpoint** (the Discord announcement at the 
    git fetch --tags
    git tag --list 'v*-*.*' --sort=-v:refname | head -1
    ```
-   Store this as `PREV_TAG` for the release body diff link in Phase 6.
-4. **Read current version**: `grep _VERSION_PRERELEASE src/OTGW-firmware/version.h` and store the current value (e.g. `beta.3`).
+   Store this as `PREV_TAG` for the release body diff link in Phase 7.
+4. **Detect the latest PUBLIC stable release**:
+   ```bash
+   LATEST_PUBLIC=$(gh release view --json tagName --jq '.tagName' 2>/dev/null \
+                   || git tag --list 'v[0-9]*.[0-9]*.[0-9]*' --sort=-v:refname \
+                        | grep -v -- '-' | head -1)
+   ```
+   Store this as `LATEST_PUBLIC`. Used by Phase 1 for the staleness diff and by the Phase 9 Discord announcement.
+5. **Read current version**: `grep _VERSION_PRERELEASE src/OTGW-firmware/version.h` and store the current value (e.g. `beta.3`).
 
-### Phase 1: ADR validation
+### Phase 1: README + CHANGELOG staleness gate (mandatory, runs first)
+
+**Why this is now Phase 1, not Phase 2.5.** The GitHub Action checks out the repo at the tag commit and reads `README.md`, `CHANGELOG.md`, and `RELEASE_NOTES_<base>-beta.md` to compose the release body. If those files are stale, the tag locks the stale narrative onto the release page (immutable releases policy — see Trap 1). The check therefore gates the bump: a stale narrative blocks Phase 2 and downstream phases until the user (or this skill) refreshes the docs.
+
+**The staleness check (run automatically):**
+
+1. List commits between `LATEST_PUBLIC` and `HEAD` on `dev`, subject only:
+   ```bash
+   git log --pretty=format:'%h %s' "${LATEST_PUBLIC}..HEAD" -- src/OTGW-firmware/ src/libraries/ docs/ data/
+   ```
+   This is the set of changes the next release page should account for. Filtering paths trims trivial chore commits.
+2. Read the existing narrative bullets:
+   - `README.md` "What's new on dev (since <LATEST_PUBLIC>)" section (between the dev banner and the "What's New in v<stable>" anchor).
+   - `CHANGELOG.md` `## [Unreleased]` section.
+   - `RELEASE_NOTES_<base>-beta.md` digest region (above the `<!-- digest:end -->` sentinel), if the file exists.
+3. **Heuristic match (not regex parsing):** for each commit subject in step 1, look for a topical match in any of the three narratives. A match can be by ADR number, TASK ID, PR number, or a substring of the subject. Missing items are listed as candidates for the user.
+4. **Decision:**
+   - **All commits accounted for** ⇒ pass silently, continue to Phase 2.
+   - **One or more commits missing from the narrative** ⇒ STOP. Print the missing-commit list, the file(s) that should receive entries (README and/or CHANGELOG and/or RELEASE_NOTES), and ask the user whether to (a) refresh the docs in this session before bumping, (b) skip the missing items deliberately (justify in the commit message), or (c) abort the beta cut.
+5. **Authoring rules** when the gate fires and you refresh in-session:
+   - `CHANGELOG.md` — append under `## [Unreleased]` using [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) headings (`### Added`, `### Changed`, `### Fixed`, `### Removed`, `### Documentation`). One short bullet per change, with the ADR/TASK/PR reference in parentheses.
+   - `README.md` — refresh the dev-banner version label and the "What's new on dev (since <LATEST_PUBLIC>)" section. Do NOT touch the "What's New in v<stable>" section; that belongs to the last shipped stable and stays as the historical anchor.
+   - `RELEASE_NOTES_<base>-beta.md` — if the line carries a narrative bigger than the CHANGELOG bullets warrant, maintain a per-line notes file at the repo root. The CI workflow inlines the content above the `<!-- digest:end -->` sentinel into the release body under a "What's new since the last public release" heading; the link below the inlined teaser points to the full file for the long form.
+
+**Skip allowed only when**: the bump is a re-cut at the same change surface (for example, the previous tag hit the immutable-release trap and we are reissuing under a fresh number). The narrative did not change, only the tag did. Note the reason in the commit message and proceed straight to Phase 2.
+
+### Phase 2: ADR validation
 
 Skip by default. Only stop and create an ADR if the staged firmware change introduces a new architectural pattern, a new dependency, or shifts an NFR (heap budget, MQTT topic shape, settings schema). Most beta cycles do not need this gate.
 
 **Conditional stop:** Only pause for user input if an ADR is actually needed.
 
-### Phase 2: Bump prerelease
+### Phase 3: Bump prerelease
 
 Run the bump helper from the project root:
 
@@ -83,21 +116,9 @@ bin/bump-prerelease.sh
 
 The helper rewrites `src/OTGW-firmware/version.h` (`_VERSION_PRERELEASE`, `_SEMVER_FULL`, `_SEMVER_NOBUILD`, `_VERSION`) and `src/OTGW-firmware/data/version.hash`. It prints the transition (e.g. `beta.3 -> beta.4`). Store the new value as `NEW_PRERELEASE`.
 
-The helper does NOT git-add. You stage the files yourself in Phase 5.
+The helper does NOT git-add. You stage the files yourself in Phase 6.
 
-### Phase 2.5: Update README and CHANGELOG (mandatory)
-
-The GitHub release body is mostly a thin shell that links *back* into the repo. Keep those targets in shape on every beta cut so testers reading the release page on mobile can find the narrative.
-
-1. **`CHANGELOG.md`** — append new entries under `## [Unreleased]` (or open a new `## [<base_version>-beta] - YYYY-MM-DD` section if you prefer to scope per beta line). Keep the [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) headings (`### Added`, `### Changed`, `### Fixed`, `### Removed`, `### Documentation`). One short bullet per change, with the ADR/TASK reference in parentheses.
-2. **`README.md`** — refresh the dev-branch banner and the "What's new on dev" / "Latest beta line" paragraph so the first screen of the README reflects what this beta carries. Do not touch the "What's New in v<stable>" section — that belongs to the last shipped stable and stays as the historical anchor.
-3. **`RELEASE_NOTES_<base_version>-beta.md`** (optional but recommended) — if the line carries a narrative bigger than the CHANGELOG bullets warrant, keep a per-line release-notes file at the repo root. The CI workflow auto-detects and links it in the release body.
-
-These three files are what the workflow links to in the GitHub release body. If any of them is stale, the release page tells testers the wrong story.
-
-**Skip allowed only when**: the bump is a re-cut at the same change surface (e.g., beta.4 hit the immutable-release trap and we are reissuing as beta.5). The README/CHANGELOG narrative did not change, only the tag did. Note the reason in the commit message.
-
-### Phase 3: Build verification (mandatory gate)
+### Phase 4: Build verification (mandatory gate)
 
 ```bash
 python build.py --firmware
@@ -105,7 +126,7 @@ python build.py --firmware
 
 Must exit 0. If the build fails, fix the issue, re-run the bump if needed, and retry. Do NOT proceed to commit or push on a broken build.
 
-### Phase 4: Evaluator (mandatory gate)
+### Phase 5: Evaluator (mandatory gate)
 
 ```bash
 python evaluate.py --quick
@@ -113,9 +134,9 @@ python evaluate.py --quick
 
 Must show no new failures. If new failures appear, fix them (or, if pre-existing baseline failures unrelated to this change, document that in the commit message). Do NOT proceed on a regressed evaluator.
 
-### Phase 5: Commit and push to dev
+### Phase 6: Commit and push to dev
 
-1. **Stage** the firmware change, the version bump, AND the documentation refresh from Phase 2.5:
+1. **Stage** the firmware change, the version bump, AND the documentation refresh from Phase 1 (if anything was refreshed in this cycle):
    ```bash
    git add src/OTGW-firmware/version.h src/OTGW-firmware/data/version.hash \
            <firmware-files> \
@@ -135,9 +156,9 @@ Must show no new failures. If new failures appear, fix them (or, if pre-existing
 
 If the pre-commit hook blocks (bump-check fails because version.h was not staged), re-stage and retry. Do NOT use `OTGW_BUMP_HOOK_DISABLE=1` here: the whole point of this skill is to bump+commit together.
 
-The README + CHANGELOG must land in the SAME commit (or a commit ordered before the tag) because the GitHub Action checks out the code at the tag and reads these files when composing the release body. Stale documentation at the tagged commit = stale release page.
+The README + CHANGELOG + RELEASE_NOTES must land in the SAME commit (or a commit ordered before the tag) because the GitHub Action checks out the code at the tag and reads these files when composing the release body. Stale documentation at the tagged commit = stale release page. Phase 1's staleness gate is what keeps this contract honest; do not skip it.
 
-### Phase 6: Create and push the prerelease tag
+### Phase 7: Create and push the prerelease tag
 
 Construct the tag from `_SEMVER_CORE` and the new prerelease label:
 
@@ -156,7 +177,7 @@ git push origin "${TAG}"
 
 The push fires `.github/workflows/beta-prerelease.yml`. The Action builds firmware + filesystem binaries, creates a GitHub release with `prerelease: true`, and uploads the `.ino.bin` and `.littlefs.bin` as assets. The existing `release-assets.yml` workflow then chains in on `release: published` to attach SHA256SUMS, `flash_otgw.sh`, `flash_otgw.bat`, and the flash-bundle zip.
 
-### Phase 7: Wait for the GitHub Action
+### Phase 8: Wait for the GitHub Action
 
 1. Open the Actions tab: `https://github.com/rvdbreemen/OTGW-firmware/actions`
 2. Watch the `Beta prerelease publish` workflow run on the new tag.
@@ -168,12 +189,12 @@ The push fires `.github/workflows/beta-prerelease.yml`. The Action builds firmwa
 
 If the Action fails, inspect the logs, fix the issue (usually a build regression or a missing secret), and either re-run via `workflow_dispatch` or push a new tag.
 
-### Phase 8: Discord announcement (CHECKPOINT)
+### Phase 9: Discord announcement (CHECKPOINT)
 
-Prepare a one-paragraph announcement for `#beta-testing` (channel ID `914498730001072149`). The Diff link points at the **latest public stable release** (`LATEST_PUBLIC`), not the previous beta — testers usually want to know what changed since the last shipping version. Get the value with:
+Prepare a one-paragraph announcement for `#beta-testing` (channel ID `914498730001072149`). The Diff link points at the **latest public stable release** (`LATEST_PUBLIC`), not the previous beta — testers usually want to know what changed since the last shipping version. Reuse the `LATEST_PUBLIC` value already resolved in Phase 0:
 
 ```bash
-LATEST_PUBLIC=$(gh release view --json tagName --jq '.tagName')
+echo "${LATEST_PUBLIC}"   # captured at the start of the flow
 ```
 
 Template:
@@ -215,7 +236,7 @@ The Action publishes the release on the SHA the tag points to, so an arbitrary c
 - **Always push to remote after every commit**: keep local and remote in sync.
 - **Never force-push to dev**: standing permission only covers normal pushes.
 - **Build and evaluator gates are mandatory**: do not push a tag if either gate is red.
-- **One checkpoint**: the Discord announcement in Phase 8. All other phases proceed automatically.
+- **One checkpoint**: the Discord announcement in Phase 9. All other phases proceed automatically.
 - **Bump-check hook is your friend**: if the pre-commit hook blocks the firmware commit, you forgot to stage `version.h` or `data/version.hash`. Fix the staging, do NOT bypass with `OTGW_BUMP_HOOK_DISABLE=1`.
 - **CI build is a deliberate departure from /release**: full releases build locally (so the maintainer toolchain is canonical), betas build in CI (so the maintainer does not pay 5 minutes per cycle). The build script (`build.py`) is the same; only the host differs.
 
@@ -251,6 +272,6 @@ Testers usually want to know what changed since the last *shipping* version, not
 
 ### Trap 5: Release body that does not link the in-repo narrative
 
-The GitHub release body composed by CI is short by design (auto-generated). Testers reading it on mobile need a one-tap path to the README, CHANGELOG, and per-line release notes.
+The GitHub release body composed by CI is short by design (auto-generated). Testers reading it on mobile need a one-tap path to the README, CHANGELOG, and per-line release notes, plus an inline preview of what changed.
 
-**Workaround in workflow:** the release body links `README.md`, `CHANGELOG.md`, and `RELEASE_NOTES_<base>-beta.md` (auto-detected at the tagged commit). These must be up-to-date at the tagged commit — see Phase 2.5.
+**Workaround in workflow:** the release body links `README.md`, `CHANGELOG.md`, and `RELEASE_NOTES_<base>-beta.md` (auto-detected at the tagged commit), and inlines the content of `RELEASE_NOTES_<base>-beta.md` above the `<!-- digest:end -->` sentinel as a "What's new since the last public release" teaser. These must be up-to-date at the tagged commit. Phase 1's staleness gate is the contractual mechanism that keeps them in sync.

--- a/.github/workflows/beta-prerelease.yml
+++ b/.github/workflows/beta-prerelease.yml
@@ -175,6 +175,9 @@ jobs:
 
           # Locate the in-repo release notes file for this build (best-effort).
           # Prefer the exact version, then the line's beta file, then archived copies.
+          # NOTES_PATH is the on-disk path (used for inlining the digest below).
+          # NOTES_LINK is the GitHub blob URL at the tag (used as the read-full link).
+          NOTES_PATH=""
           NOTES_LINK=""
           for candidate in \
             "RELEASE_NOTES_${VERSION}.md" \
@@ -183,11 +186,31 @@ jobs:
             "docs/releases/RELEASE_NOTES_${BASE_VERSION}-beta.md"
           do
             if [ -f "${candidate}" ]; then
+              NOTES_PATH="${candidate}"
               NOTES_LINK="https://github.com/${REPO}/blob/${TAG}/${candidate}"
               echo "Release notes file at tagged commit: ${candidate}"
               break
             fi
           done
+
+          # Extract the digest (content above the '<!-- digest:end -->' sentinel)
+          # for inline preview in the release body. If the sentinel is missing,
+          # inline the whole file. If no notes file was found, the inline
+          # section is omitted entirely (graceful fallback to the pre-digest
+          # release body shape).
+          DIGEST_FILE=""
+          if [ -n "${NOTES_PATH}" ]; then
+            DIGEST_FILE="release_body_digest.md"
+            if grep -q '<!-- digest:end -->' "${NOTES_PATH}"; then
+              awk '/<!-- digest:end -->/{exit} {print}' "${NOTES_PATH}" > "${DIGEST_FILE}"
+              echo "Digest extracted from ${NOTES_PATH} (above '<!-- digest:end -->' marker)."
+            else
+              cp "${NOTES_PATH}" "${DIGEST_FILE}"
+              echo "WARN: ${NOTES_PATH} has no '<!-- digest:end -->' sentinel; inlining the entire file as the release-page digest."
+            fi
+            # Strip the leading H1 if present; the release body provides its own H2 heading.
+            sed -i '1{/^# /d}' "${DIGEST_FILE}"
+          fi
 
           {
             echo "Beta prerelease **${TAG}**."
@@ -199,9 +222,19 @@ jobs:
             echo "- [\`README.md\`](https://github.com/${REPO}/blob/${TAG}/README.md) — landing page and current dev-line status."
             echo "- [\`CHANGELOG.md\`](https://github.com/${REPO}/blob/${TAG}/CHANGELOG.md) — running change log for the next release."
             if [ -n "${NOTES_LINK}" ]; then
-              echo "- [Release notes for this line](${NOTES_LINK})."
+              echo "- [Read the full release notes for this line](${NOTES_LINK})."
             fi
             echo ""
+            if [ -n "${DIGEST_FILE}" ] && [ -s "${DIGEST_FILE}" ]; then
+              echo "## What's new since the last public release"
+              echo ""
+              cat "${DIGEST_FILE}"
+              echo ""
+              if [ -n "${NOTES_LINK}" ]; then
+                echo "_Read the full release notes: [${NOTES_PATH}](${NOTES_LINK})._"
+                echo ""
+              fi
+            fi
             echo "### Compare to the latest public release"
             echo ""
             if [ -n "${PREV}" ]; then

--- a/RELEASE_NOTES_1.6.0-beta.md
+++ b/RELEASE_NOTES_1.6.0-beta.md
@@ -1,0 +1,86 @@
+# 1.6.0-beta release notes
+
+These are the release notes for the `1.6.0-beta.N` line on `dev`. The line builds on `1.5.0-fix2` (the current latest public stable) and tracks the next stable release, `1.6.0`. Field testers can flash any `v1.6.0-beta.*` prerelease from the [Releases page](https://github.com/rvdbreemen/OTGW-firmware/releases) and should report findings in Discord `#beta-testing`.
+
+The bullets below summarise the user-visible changes that have landed on `dev` since the last public stable, `v1.5.0-fix2`.
+
+**MQTT and Home Assistant discovery**
+- **HA availability now reflects the MQTT link, not the OpenTherm bus** (ADR-074, regression fix). Entities like `DHW Control` and `Thermostat` no longer flap `unavailable` when the boiler stops talking. OT-bus liveness lives on the dedicated `otgw_connected` sensor. **Contract change:** consumers reading the base `<toptopic>/value/<nodeid>` topic as OT-bus liveness must migrate to `otgw_connected`.
+- **Pure JIT MQTT discovery** (ADR-073, supersedes ADR-041): only non-OT pseudo-IDs queue at boot; OT MsgID discovery configs publish on first MsgID reception. Stalled-discovery edge case fixed by aligning the JIT trigger with the force-path `hasConfig` filter.
+- **Proxy-answer (no-B) routing fix** (ADR-075): MsgIDs without a boiler response now route to the correct worldview topic instead of going silent.
+- **MsgID 0 Status canonical publish** gated on boiler-side worldview so the canonical topic no longer flaps on thermostat-only frames.
+- **HA PIC-control entities**: new `button` and `select` discovery configs under pseudo-ID 251 expose the PIC reset and mode controls as proper HA entities.
+- **Standalone HA discovery topic wiper**: one-shot helper for cleaning stale retained discovery topics out of the broker.
+
+**Web UI and diagnostics**
+- **FSexplorer "Update Firmware" button** is visible again on touch-capable desktops; the touch-class media query no longer hides the upload control.
+- **Set-command debug surfacing**: silently-dropped set-commands now appear in the default debug stream instead of being swallowed.
+
+**Tooling and build**
+- **Flash scripts hardened**: `flash_otgw.sh` / `flash_otgw.bat` now mirror spec parity, verify SHA256 integrity, and pick the binary that matches the requested version. The `.bat` variant detects COM ports through the Windows registry and auto-downloads binaries when not found locally.
+- **`build.py` auto-initialises missing git submodules** so a fresh clone or stale checkout builds without manual `git submodule update`.
+- **`evaluate.py`** false-positive and stale checks fixed; the gate is now meaningful again.
+- **`/beta-prerelease` skill + GitHub Action** for tag-driven (and, after the May 2026 workflow refresh, workflow-dispatch-driven) beta publishing, with draft-first asset attachment to satisfy GitHub's immutable-releases policy.
+
+**Code hygiene**
+- **Dead and orphaned code paths cleaned out of `dev`**: inactive subsystem code and its matching scaffolding in `OTGW-firmware.h` removed, since neither is reachable on the 1.5.x / 1.6.x line.
+
+For per-commit detail see [`CHANGELOG.md`](CHANGELOG.md) under `## [Unreleased]`. For architectural rationale see the linked ADRs under [`docs/adr/`](docs/adr/).
+
+<!-- digest:end -->
+
+## Full per-line detail (since v1.5.0-fix2)
+
+Below is the long-form version of the digest above, with one section per area and explicit cross-references. The CI workflow inlines only the digest (everything above the `<!-- digest:end -->` marker) into the release body; this section is here for testers who follow the "Read the full release notes" link.
+
+### MQTT contract changes (worth a second read)
+
+- **HA availability decoupling (ADR-074, TASK-607).** Before this release, `<toptopic>/value/<nodeid>` doubled as the HA availability topic AND the OT-bus liveness indicator. The two are different things: when the boiler stops talking, MQTT is still healthy, but every entity went `unavailable`. As of `1.6.0-beta.N`, the HA availability topic reflects only the ESP↔MQTT link (birth/LWT). OT-bus liveness is on the dedicated `otgw_connected` sensor.
+  - **Action for tester:** if any of your automations or dashboards key off the base value topic to detect that the boiler is talking, switch them to the `otgw_connected` sensor instead. The base value topic is no longer reliable for that purpose.
+- **JIT (just-in-time) discovery (ADR-073, supersedes ADR-041).** Discovery configs for OpenTherm MsgIDs are no longer published at boot. They publish the first time the gateway sees a value for that MsgID, which trims a large startup burst and means HA only sees entities that are actually relevant to the connected boiler+thermostat. Boot-time discovery still applies to the small set of non-OT pseudo-IDs (climate, number, Dallas, heap stats, firmware/PIC). The `F` force-republish action remains available for one-shot recovery.
+- **MsgID 0 Status gating (TASK-633).** The canonical `Status` topic now gates on the boiler-side worldview so it stops flapping on thermostat-only frames. This is a quality-of-life fix; no automation contract change.
+
+### Web UI fixes worth field-validating
+
+- **FSexplorer Update Firmware button on touch desktops (GitHub #575, #598).** The touch-class CSS media query no longer hides the upload control. If you are running a touchscreen all-in-one PC and previously could not see the Update Firmware button, please confirm it is back.
+
+### Tooling that may affect your normal workflow
+
+- **`flash_otgw.sh` / `flash_otgw.bat` (PR #570).** Both scripts now share a spec-defined argument surface, verify the binary against `SHA256SUMS` before flashing, and pick the right `.ino.bin` / `.littlefs.bin` pair for the requested version. The Windows variant detects the OTGW's COM port through the registry and downloads the binaries from the GitHub release page when not present locally.
+- **`build.py` (PR #594).** The build script now runs `git submodule update --init --recursive` for any submodule that is missing or empty. A fresh clone no longer requires you to remember the manual step.
+- **`evaluate.py` (PR #592).** A handful of false-positives and one stale-check bug are fixed. CI's evaluator gate is meaningful again.
+- **`/beta-prerelease` skill and `.github/workflows/beta-prerelease.yml`.** Beta cuts are now tag-driven (or, after the May 2026 refresh, workflow-dispatch-driven from the Actions UI). The Action publishes the release with all assets attached in one atomic draft-first call so the GitHub "immutable releases" policy does not trap stuck drafts.
+
+### Documentation
+
+- New integration guides for **openHAB** and **Domoticz**.
+- New Dutch beginner guide for cleaning up stale MQTT topics in MQTT Explorer (`docs/guides/MQTT_STALE_TOPICS_CLEANUP*.md`).
+- PIC and ESP firmware guides split into EN/NL language variants, with PIC guide scope restored and ESP-flash docs routed to `FLASH_GUIDE.md`.
+- API and ADR docs refreshed mid-cycle: `docs/api/MQTT.md` documents the boot vs. JIT discovery split per ADR-073; `docs/api/README.md` corrects the `/discovery/verify` REST endpoint description; `docs/adr/README.md` gains ADR-041 (Superseded) and ADR-073 (Accepted) index entries.
+- Release-notes housekeeping: `RELEASE_NOTES_1.5.0.md` and `RELEASE_GITHUB_1.5.0.md` moved out of the repo root into `docs/releases/`; older `1.3.3` and `1.3.4` notes archived under `docs/releases/archive/`.
+- Documentation link paths normalised; markdown link-validation guardrail introduced (PR #573) and CI scope extended to `docs/guides/` and `docs/process/` (PR #581) to keep documentation cross-links honest.
+
+### Removed
+
+- Dead and orphaned subsystem code paths cleaned out of `dev` (PR #586, PR #589). Neither was reachable on the 1.5.x / 1.6.x line.
+- Accidentally committed root files removed; `.gitignore` tightened so they cannot return (TASK-635, PR #606).
+
+## How to test
+
+1. **Flash** a `v1.6.0-beta.*` release using the Web UI (`Update Firmware`), the OTA route, or the `flash_otgw.sh` / `flash_otgw.bat` helper from a clone of the repo.
+2. **Watch HA discovery.** Entities should NOT flap `unavailable` if the boiler is quiet but MQTT is up. The `otgw_connected` sensor should track OT-bus liveness instead.
+3. **Force a discovery re-publish** if you previously saw a stalled-discovery state, by sending `F` over MQTT or via the Web UI (`Republish`). Confirm all expected entities appear.
+4. **Try the touch-desktop scenario** if you run a touchscreen workstation: open FSexplorer, confirm the Update Firmware button is visible.
+5. **Report findings** in Discord `#beta-testing`. Both positive ("looks good on my boiler model X") and negative reports help.
+
+## Compatibility and breaking changes
+
+- **HA availability source change (see ADR-074 above).** If your dashboards or automations depend on the base value topic being absent to detect that the boiler is silent, they need to migrate to `otgw_connected`. No firmware-side change can preserve the old behaviour while fixing the regression that motivated this change; field testers should review their HA configs once and adapt.
+- No partition-layout changes. The `4M2M` layout introduced in v1.5.0 is preserved. Upgrading from v1.5.0-fix2 to a `1.6.0-beta.N` does not require a filesystem reformat.
+
+## Where to read more
+
+- [`CHANGELOG.md`](CHANGELOG.md): per-commit running log under `## [Unreleased]`.
+- [`README.md`](README.md): landing page, "What's new on dev" section.
+- [`docs/adr/`](docs/adr/): architectural rationale, in particular ADR-073 (JIT discovery), ADR-074 (HA availability), ADR-075 (proxy-answer routing).
+- [`docs/guides/`](docs/guides/): flash, build, MQTT, and integration guides.

--- a/backlog/tasks/task-639 - Inline-since-last-public-release-digest-in-beta-GitHub-release-body.md
+++ b/backlog/tasks/task-639 - Inline-since-last-public-release-digest-in-beta-GitHub-release-body.md
@@ -1,9 +1,11 @@
 ---
 id: TASK-639
 title: Inline 'since last public release' digest in beta GitHub release body
-status: To Do
-assignee: []
+status: In Progress
+assignee:
+  - '@claude'
 created_date: '2026-05-20 15:36'
+updated_date: '2026-05-20 15:36'
 labels:
   - release
   - docs
@@ -26,4 +28,6 @@ The beta-prerelease.yml workflow currently composes a thin release body that onl
 - [ ] #5 When the notes file exists but has no digest-end sentinel, the workflow inlines the entire file (best-effort behaviour, documented in the workflow comments).
 - [ ] #6 python build.py --firmware exits 0 and python evaluate.py --quick shows no new failures on the commit that introduces the change.
 - [ ] #7 Changes commit to claude/beta-release-prep-qUipc and a draft PR is opened against dev.
+- [ ] #8 .claude/skills/beta-prerelease/SKILL.md is restructured so the README + CHANGELOG check is moved from Phase 2.5 (after bump) to Phase 1 (before bump). The check gates the rest of the flow: if README's 'What's new on dev' or CHANGELOG's [Unreleased] section is stale relative to commits since the last public stable, the skill halts and asks the user to refresh first.
+- [ ] #9 Skill text spells out the staleness check explicitly: a deterministic pre-flight that diffs commit log since the latest public stable (gh release view --json tagName) against the bullets already present in README/CHANGELOG, calling out any commit subject not yet narrated. Heuristic, not a hard regex match.
 <!-- AC:END -->

--- a/backlog/tasks/task-639 - Inline-since-last-public-release-digest-in-beta-GitHub-release-body.md
+++ b/backlog/tasks/task-639 - Inline-since-last-public-release-digest-in-beta-GitHub-release-body.md
@@ -31,3 +31,16 @@ The beta-prerelease.yml workflow currently composes a thin release body that onl
 - [ ] #8 .claude/skills/beta-prerelease/SKILL.md is restructured so the README + CHANGELOG check is moved from Phase 2.5 (after bump) to Phase 1 (before bump). The check gates the rest of the flow: if README's 'What's new on dev' or CHANGELOG's [Unreleased] section is stale relative to commits since the last public stable, the skill halts and asks the user to refresh first.
 - [ ] #9 Skill text spells out the staleness check explicitly: a deterministic pre-flight that diffs commit log since the latest public stable (gh release view --json tagName) against the bullets already present in README/CHANGELOG, calling out any commit subject not yet narrated. Heuristic, not a hard regex match.
 <!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Restructure .claude/skills/beta-prerelease/SKILL.md so README + CHANGELOG check moves to Phase 1 (before bump). Spell out the deterministic staleness check: git log v<latest-public>..HEAD vs README 'What's new' bullets + CHANGELOG [Unreleased].
+2. Create RELEASE_NOTES_1.6.0-beta.md at the repo root. Top section is the digest (curated summary of changes since v1.5.0-fix2, sourced from the README 'What's new on dev' section, trimmed and adapted for the release page). Sentinel: <!-- digest:end -->. Below the sentinel: full-detail bullets per major area (matching CHANGELOG [Unreleased] but in reader-oriented prose).
+3. Modify .github/workflows/beta-prerelease.yml: in the 'Compose release body' step, after the existing notes-file detection loop, read the file content up to the digest sentinel (sed -n '1,/digest:end/p' minus the marker), then echo it under a new '## What's new since the last public release' heading placed between 'What is in this build' and 'Compare to the latest public release'. Keep the existing 'Release notes for this line' link as the 'read full' affordance.
+4. Build verification: python build.py --firmware (must exit 0).
+5. Evaluator: python evaluate.py --quick (no new failures).
+6. Commit on claude/beta-release-prep-qUipc with conventional message describing all three changes (skill restructure, notes file, workflow inline).
+7. Push branch and open draft PR against dev so the maintainer can review before the next tag push.
+8. Mark all ACs and set status to Done.
+<!-- SECTION:PLAN:END -->

--- a/backlog/tasks/task-639 - Inline-since-last-public-release-digest-in-beta-GitHub-release-body.md
+++ b/backlog/tasks/task-639 - Inline-since-last-public-release-digest-in-beta-GitHub-release-body.md
@@ -1,0 +1,29 @@
+---
+id: TASK-639
+title: Inline 'since last public release' digest in beta GitHub release body
+status: To Do
+assignee: []
+created_date: '2026-05-20 15:36'
+labels:
+  - release
+  - docs
+  - ci
+dependencies: []
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+The beta-prerelease.yml workflow currently composes a thin release body that only links README.md, CHANGELOG.md, and (if present) RELEASE_NOTES_<base>-beta.md. Field testers reading the release page on mobile want a narrative summary of what changed since the last shipping version, inline. Curate that summary in a new RELEASE_NOTES_1.6.0-beta.md at repo root, use an HTML-comment sentinel to mark a teaser region, and modify the workflow to inline the teaser between the 'What is in this build' section and the 'Compare to the latest public release' section.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 RELEASE_NOTES_1.6.0-beta.md exists at the repo root with a curated 'What's new since v1.5.0-fix2' narrative, grouped by area (MQTT/HA discovery, Web UI/diagnostics, tooling/build, code hygiene, documentation). No em dashes.
+- [ ] #2 The notes file contains an HTML-comment digest-end sentinel (e.g. '<!-- digest:end -->') marking the teaser cutoff. Content above the sentinel is the release-page digest; content below is the long-form detail referenced via the existing 'Read full release notes' link.
+- [ ] #3 .github/workflows/beta-prerelease.yml inlines the teaser content (lines 1..sentinel, sentinel line stripped) under a new '## What's new since the last public release' heading inside the composed release body, placed between 'What is in this build' and 'Compare to the latest public release'.
+- [ ] #4 When no notes file is found at the tagged commit, the workflow falls back to the previous behaviour (no inline summary, no 'Read full release notes' link) without erroring.
+- [ ] #5 When the notes file exists but has no digest-end sentinel, the workflow inlines the entire file (best-effort behaviour, documented in the workflow comments).
+- [ ] #6 python build.py --firmware exits 0 and python evaluate.py --quick shows no new failures on the commit that introduces the change.
+- [ ] #7 Changes commit to claude/beta-release-prep-qUipc and a draft PR is opened against dev.
+<!-- AC:END -->


### PR DESCRIPTION
## Summary

Two improvements to the beta-prerelease flow, both motivated by recent observation that the GitHub release page for a beta tag carries only a thin shell (asset list + links) and that a stale README/CHANGELOG could permanently lock onto a tagged release because the GitHub Action checks out at the tag commit.

### 1. README/CHANGELOG check moves to Phase 1 (was Phase 2.5)

`.claude/skills/beta-prerelease/SKILL.md` is restructured so the narrative-refresh gate runs **before** the version bump:

- Phase 0: Prepare (clean state, detect tags, resolve `LATEST_PUBLIC`)
- **Phase 1: README + CHANGELOG staleness gate** (was 2.5, post-bump)
- Phase 2: ADR validation
- Phase 3: Bump prerelease
- Phase 4: Build
- Phase 5: Evaluator
- Phase 6: Commit + push
- Phase 7: Tag
- Phase 8: Wait for CI
- Phase 9: Discord checkpoint

Phase 1 spells out a deterministic staleness check: `git log <LATEST_PUBLIC>..HEAD` on the firmware/docs paths, cross-referenced against the bullets in README's "What's new on dev" section, CHANGELOG's `[Unreleased]` section, and the digest region of `RELEASE_NOTES_<base>-beta.md` (if present). When a commit subject has no topical match in any of the three narratives, the skill halts and asks the user to refresh first. Heuristic matching by ADR/TASK/PR/substring, not regex parsing.

### 2. Inline 'since last public release' digest in the GitHub release body

- New `RELEASE_NOTES_1.6.0-beta.md` at the repo root. Top half is the curated digest (sourced from README's "What's new on dev", tightened for the release page, grouped by MQTT/HA, Web UI/diagnostics, tooling/build, code hygiene, documentation). Cut marker: `<!-- digest:end -->`. Bottom half is full per-area detail.
- `.github/workflows/beta-prerelease.yml` inlines the digest content (above the sentinel) under a new `## What's new since the last public release` heading in the release body, placed between "What is in this build" and "Compare to the latest public release". Existing `Release notes for this line` link becomes `Read the full release notes for this line`.
- Graceful fallbacks: no notes file → no inline section; no sentinel → inline the whole file with a workflow log warning.

The release body composition is a single `awk` extract + `sed` cleanup; YAML parse passes; the workflow's `gh release create --draft ...` and `gh release edit --draft=false` flow is untouched.

## Test plan

- [x] python build.py --firmware exits 0
- [x] python evaluate.py --quick: 34 checks pass, 0 failures (info-only items unchanged from baseline)
- [x] YAML parses (`python3 -c "import yaml; yaml.safe_load(open('.github/workflows/beta-prerelease.yml'))"`)
- [x] Local simulation of `awk '/<!-- digest:end -->/{exit} {print}' RELEASE_NOTES_1.6.0-beta.md` produces a 28-line digest with the expected sections and no markdown artefacts
- [x] No em dashes introduced in `RELEASE_NOTES_1.6.0-beta.md` or in my added workflow lines
- [ ] End-to-end CI run on the next beta tag push (will validate the inline section on the actual GitHub release page)

## Related

- TASK-639 (this PR)
- TASK-637 / TASK-638 (the README + CHANGELOG refresh that this gate now enforces structurally)

Draft until the next beta tag exercises the CI path end to end.

https://claude.ai/code/session_018Z2y9SErKo9e5xiTDLoFHA

---
_Generated by [Claude Code](https://claude.ai/code/session_018Z2y9SErKo9e5xiTDLoFHA)_