### PR TITLE
chore(gitignore): ignore .claude/worktrees/ (harness-managed agent scratch)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,6 +57,7 @@ logs-issue/*
 .claude/github_last_checked.txt
 .claude/tweakers_last_checked.txt
 .wolf/
+.claude/worktrees/
 tools/esptool/
 
 # Accidental root drops (TASK-635): seen via GitHub web UI uploads / empty stubs.


### PR DESCRIPTION
## Summary

- Add `.claude/worktrees/` to `.gitignore` so the Claude Code harness's per-agent isolated-worktree scratch checkouts (`agent-<id>/`) don't show up as untracked files.
- One-line `.gitignore` change, placed in the existing harness-state block between `.wolf/` and `tools/esptool/`.

## Context

This research branch was used as scratch for an in-conversation investigation comparing HA core's `opentherm_gw` integration with this firmware's MQTT/discovery layout. The substantive deliverables from that conversation are tracked separately on their respective branches:

- **TASK-648** — HA discovery three-device split, milestone v2.1.0 — committed on `feature-dev-2.0.0-otgw32-esp32-sat-support` (`2a67bf50`).
- **TASK-649** — Audit HA capability-flag binary_sensors vs HA core semantics, non-breaking — committed on `dev` (`3e9aa079`). Audit work in flight.

This PR is just the gitignore hygiene fix discovered while running the worktree-isolated audit agent.

## Test plan

- [ ] Spawn a worktree-isolated agent and confirm `.claude/worktrees/agent-*` no longer surfaces in `git status`.
- [ ] No build or evaluator gate — pure tooling-config change, docs-only path.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XzWGoCm9PUUvx7Hgf135qW)_