### PR TITLE
docs(esp-abstraction): persist audit, add evaluate.py guardrail, document rule in CLAUDE/AGENTS [TASK-739]

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -68,6 +68,21 @@ Stream files instead of loading them into RAM. Files larger than roughly 2 KB sh
 
 Do not add HTTPS or WSS support in firmware. This project targets trusted LAN deployment; REST can sit behind an HTTPS reverse proxy, while WebSocket assumptions remain plain WS.
 
+### ESP Platform Abstraction
+
+The 2.0.0 branch carries an explicit platform abstraction. **No `#if(def) ESP8266`, `#if(def) ESP32`, `#if(def) ARDUINO_ARCH_ESP*`, or `#if(def) BOARD_NODOSHOP_ESP*` may appear outside the allowlisted abstraction files.** The allowlist is: `src/OTGW-firmware/platform.h`, `platform_esp8266.h`, `platform_esp32.h`, `boards.h`, and the `OTGW-ModUpdateServer{.h,-esp32.h,-impl.h}` trio.
+
+Application code must instead:
+
+- Call `platformXxx()` shims from `platform_*.h` for any divergent API (heap, hostname, MAC, reset, NTP, LED, JSON tx, WiFi, BLE, ...). If the shim you need does not exist, **add it first** in both `platform_esp8266.h` and `platform_esp32.h` (use an inline no-op stub on the platform where the feature is absent), then call it unguarded from application code.
+- Gate optional features with `HAS_*` capability flags from `boards.h` (`HAS_PIC`, `HAS_DIRECT_OT`, `HAS_ETH_CAPABLE`, `HAS_OLED_CAPABLE`, `HAS_SAT_BLE`, `HAS_WEATHER_FORECAST`, etc.). If your feature has no flag yet, add one to `boards.h` first.
+- Never reference raw board macros (`BOARD_NODOSHOP_ESP32`, ...) outside `boards.h`. Those decide which `HAS_*` flags are set; the rest of the firmware sees only the `HAS_*` flags.
+- Never call `ESP.getXxx()` directly when a `platformXxx()` shim exists (`platformFreeHeap`, `platformMinFreeHeap`, `platformMaxFreeBlock`, `platformHeapFragmentation`, `platformRestart`, `platformChipId`, `platformFlashChip*`, ...). Bypassing the shim is a quieter form of the same leak.
+
+When adding a feature that diverges per platform, write the shim or the `HAS_*` flag first, the application code second. Platform headers are the public API of the abstraction; `.ino` files are clients.
+
+`evaluate.py::check_esp_abstraction_boundary()` enforces this with a baseline-ratchet: FAIL on any new violation above `ESP_ABSTRACTION_BASELINE`, WARN while any pre-existing violation remains. The current baseline, full leak inventory, and tiered remediation plan live in `docs/audits/2026-05-28-esp-abstraction-leak-audit.md` (TASK-739) and tasks TASK-740..746. Every remediation tier task must lower `ESP_ABSTRACTION_BASELINE` in `evaluate.py` as part of its Definition of Done.
+
 ### Architecture rules
 
 - PIC commands must go through `addOTWGcmdtoqueue()`. Do not write command bytes directly to the PIC serial path.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -130,6 +130,58 @@ Files >2 KB: `httpServer.streamFile()`. `index.html` is ~11 KB — never `f.read
 
 Trusted LAN only. REST API works behind HTTPS reverse proxy, but WebSocket assumes plain WS.
 
+### ESP Platform Abstraction — no raw `#ifdef ESP8266`/`ESP32` outside the abstraction layer
+
+The 2.0.0 branch carries an explicit platform abstraction so that
+application code is written against shims and capability flags, never
+against raw platform symbols. **No `#if(def) ESP8266`, `#if(def) ESP32`,
+`#if(def) ARDUINO_ARCH_ESP*`, or `#if(def) BOARD_NODOSHOP_ESP*` may appear
+outside the allowlisted abstraction files.**
+
+Allowlisted files (the only place these conditionals belong):
+
+- `src/OTGW-firmware/platform.h` — dispatcher
+- `src/OTGW-firmware/platform_esp8266.h` — ESP8266 includes, shims, type aliases
+- `src/OTGW-firmware/platform_esp32.h` — ESP32 includes, shims, type aliases
+- `src/OTGW-firmware/boards.h` — pin maps and `HAS_*` capability flags
+- `src/OTGW-firmware/OTGW-ModUpdateServer{.h,-esp32.h,-impl.h}` — parallel mini-abstraction for the firmware update server
+
+Application code MUST instead:
+
+1. **Call `platformXxx()` shims** from `platform_*.h` for any divergent API
+   (heap, hostname, MAC, reset, NTP, LED, JSON tx, WiFi, BLE, …). If a
+   shim does not exist yet for a divergence you need, *add the shim first*
+   in both `platform_esp8266.h` and `platform_esp32.h` — including an
+   inline no-op stub on the platform where the feature is absent — and
+   then call it unguarded from application code.
+2. **Gate optional features with `HAS_*` flags** from `boards.h`
+   (`HAS_PIC`, `HAS_DIRECT_OT`, `HAS_ETH_CAPABLE`, `HAS_OLED_CAPABLE`,
+   `HAS_SAT_BLE`, `HAS_WEATHER_FORECAST`, etc.). If your feature does not
+   yet have a flag, add one to `boards.h` first.
+3. **Never read raw board macros (`BOARD_NODOSHOP_ESP32`, …) outside
+   `boards.h`.** Those decide which `HAS_*` flags are set; the rest of
+   the firmware sees only the `HAS_*` flags.
+4. **Never call `ESP.getXxx()` directly** when a `platformXxx()` shim
+   already exists (`platformFreeHeap`, `platformMinFreeHeap`,
+   `platformMaxFreeBlock`, `platformHeapFragmentation`, `platformRestart`,
+   `platformChipId`, `platformFlashChip*`, etc.). Skipping the shim is a
+   quieter form of the same leak — it bypasses the platform's substitution
+   point.
+
+When adding a new feature that diverges per platform, the **first** thing
+to write is the shim or the `HAS_*` flag, not the application code that
+needs it. The platform headers are the public API of the abstraction; the
+.ino files are clients.
+
+`evaluate.py::check_esp_abstraction_boundary()` enforces this rule with a
+baseline-ratchet: it FAILs on any new violation above the recorded
+`ESP_ABSTRACTION_BASELINE` and WARNs while any pre-existing violation
+remains. The current baseline and remediation roadmap live in
+`docs/audits/2026-05-28-esp-abstraction-leak-audit.md` (TASK-739) and the
+tier tasks TASK-740..746. **Each tier task must lower
+`ESP_ABSTRACTION_BASELINE` in `evaluate.py` as part of its Definition of
+Done.**
+
 ### Architecture rules
 
 - PIC commands: always `addOTWGcmdtoqueue()`, never direct serial write

--- a/backlog/tasks/task-739 - ESP-abstraction-audit-persist-findings-guardrail-instructions.md
+++ b/backlog/tasks/task-739 - ESP-abstraction-audit-persist-findings-guardrail-instructions.md
@@ -1,0 +1,64 @@
+---
+id: TASK-739
+title: 'ESP abstraction audit: persist findings, guardrail, instructions'
+status: In Progress
+assignee:
+  - '@claude'
+created_date: '2026-05-28 08:27'
+updated_date: '2026-05-28 08:37'
+labels: []
+dependencies: []
+ordinal: 66000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Persist the senior ESP-IoT audit findings of the abstraction layer leaks identified across the 2.0.0 feature branch. Write the audit document, add a build-time guardrail in evaluate.py, update CLAUDE.md/AGENTS.md with the no-#ifdef-outside-abstraction rule. The remediation tier tasks (Tier 0-6) are created separately and tracked as siblings.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Audit document persisted at docs/audits/esp-abstraction-leak-audit-YYYY-MM-DD.md with full findings, categories, file:line references, and prioritised tier roadmap
+- [x] #2 CLAUDE.md gains an ESP Platform Abstraction rule under Critical Coding Rules clearly stating: no #ifdef ESP8266/ESP32/ARDUINO_ARCH_ESP* outside abstraction layer; call platform*() shims or use HAS_* board flags
+- [x] #3 AGENTS.md gains the equivalent rule in its Architecture rules section
+- [x] #4 evaluate.py adds a check that fails on new #if(def) ESP8266/ESP32/ARDUINO_ARCH_ESP* lines outside the abstraction file allowlist; existing violations enumerated in the audit are baselined so existing code does not break the gate
+- [x] #5 Existing-violation baseline is documented (count + file list) so the count can only decrease over time
+- [ ] #6 python build.py --firmware exits 0 on this branch
+- [x] #7 python evaluate.py --quick exits 0 (no new failures beyond the documented baseline)
+- [ ] #8 Branch pushed to origin and draft PR created
+<!-- AC:END -->
+
+
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Map abstraction layer surface (platform.h / platform_esp*.h / boards.h / OTGW-ModUpdateServer trio).
+2. Enumerate every #if/#ifdef ESP8266/ESP32/ARDUINO_ARCH_ESP*/BOARD_NODOSHOP_ESP* outside the allowlist; capture file:line:context.
+3. Group findings by remediation pattern (file-level feature modules, struct-field divergence, tuning constants, missing shims, missing stubs, board-macro leaks, OLED FreeRTOS coupling, shim-bypass, type-ambiguity overloads).
+4. Write docs/audits/2026-05-28-esp-abstraction-leak-audit.md with full findings and tier roadmap.
+5. Create Tier 0..6 backlog tasks each scoped to a single remediation theme.
+6. Implement evaluate.py::check_esp_abstraction_boundary() with baseline ratchet (FAIL on regression, WARN until zero, PASS at zero).
+7. Add ESP Platform Abstraction rule to CLAUDE.md (Critical Coding Rules) and AGENTS.md (Architecture rules).
+8. Verify guardrail: import-test, dry-run check, simulated regression FAIL.
+9. Commit, push, draft PR.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+2026-05-28: Audit complete. Baseline locked at 78 violations across 18 files (commit 9be88a0d).
+
+Deliverables landed:
+- docs/audits/2026-05-28-esp-abstraction-leak-audit.md
+- evaluate.py: scan_esp_abstraction_violations() + check_esp_abstraction_boundary() + ESP_ABSTRACTION_BASELINE constant + allowlist + wiring into evaluate_all essentials
+- CLAUDE.md: ESP Platform Abstraction section under Critical Coding Rules
+- AGENTS.md: matching ESP Platform Abstraction section under Architecture rules
+- TASK-740..746: Tier 0..6 remediation tasks (To Do)
+
+Validation:
+- python3 evaluate.py --quick: 64 PASS, 1 WARN (the new gate at baseline), 0 FAIL, 7 INFO. Health 98.6%, exit 0.
+- Simulated regression (BASELINE=77 with count=78): gate FAILs as designed.
+- Cannot run python build.py --firmware in this sandbox (outbound SSL to github.com blocked for esp32-3.3.5.tar.xz toolchain fetch). All changes are docs + Python lint, no firmware C/C++ touched.
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-740 - ESP-abstraction-Tier-0-add-HAS_SAT_BLE-HAS_WEATHER_FORECAST-HAS_SAT-feature-flags-to-boards.h.md
+++ b/backlog/tasks/task-740 - ESP-abstraction-Tier-0-add-HAS_SAT_BLE-HAS_WEATHER_FORECAST-HAS_SAT-feature-flags-to-boards.h.md
@@ -1,0 +1,30 @@
+---
+id: TASK-740
+title: >-
+  ESP abstraction Tier 0: add HAS_SAT_BLE, HAS_WEATHER_FORECAST, HAS_SAT feature
+  flags to boards.h
+status: To Do
+assignee: []
+created_date: '2026-05-28 08:28'
+labels:
+  - esp-abstraction-audit
+  - refactor
+dependencies: []
+ordinal: 67000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Infrastructure work that all higher tiers depend on. Add three feature flags in boards.h: HAS_SAT (1 on ESP32 boards, 0 on ESP8266), HAS_SAT_BLE (1 only when BLE hardware present), HAS_WEATHER_FORECAST (1 when forecast feature should be compiled in; default to current ESP32-only behaviour). No application-code changes in this tier - just the flags and short comments explaining each.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 boards.h defines HAS_SAT for every supported BOARD_NODOSHOP_* with the correct value
+- [ ] #2 boards.h defines HAS_SAT_BLE for every supported board
+- [ ] #3 boards.h defines HAS_WEATHER_FORECAST for every supported board
+- [ ] #4 Each flag is documented inline with a one-line comment naming its rationale
+- [ ] #5 python build.py --firmware passes on both ESP8266 and ESP32 board configs (no functional change yet, just new macros)
+- [ ] #6 References docs/audits/esp-abstraction-leak-audit-YYYY-MM-DD.md section Tier 0
+<!-- AC:END -->

--- a/backlog/tasks/task-741 - ESP-abstraction-Tier-1-collapse-SATweather-and-SATble-per-line-ifdefs-to-feature-flag-gates-switch-raw-ESP.-calls-to-existing-shims.md
+++ b/backlog/tasks/task-741 - ESP-abstraction-Tier-1-collapse-SATweather-and-SATble-per-line-ifdefs-to-feature-flag-gates-switch-raw-ESP.-calls-to-existing-shims.md
@@ -1,0 +1,32 @@
+---
+id: TASK-741
+title: >-
+  ESP abstraction Tier 1: collapse SATweather and SATble per-line ifdefs to
+  feature-flag gates; switch raw ESP.* calls to existing shims
+status: To Do
+assignee: []
+created_date: '2026-05-28 08:28'
+labels:
+  - esp-abstraction-audit
+  - refactor
+dependencies: []
+ordinal: 68000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Two distinct cleanup wins that together remove ~20 leaks without inventing any new shims. (a) Replace the 11 inner #ifndef ESP8266 blocks scattered across SATweather.ino with one outer #if HAS_WEATHER_FORECAST. Replace SATble.ino's file-level #if defined(ESP32) with #if HAS_SAT_BLE. (b) Substitute raw ESP.getXxx() calls with the existing platform*() shims at: restAPI.ino:1639/1641/1642/1644/1646 (heap stats - drop the #ifdef entirely), handleDebug.ino:25/27/28/30/32 (heap stats - drop the #ifdef), OLED.ino:279 (single getFreeHeap), MQTTstuff.ino:1922 (getFreeHeap in heap predicate). Depends on Tier 0.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 SATweather.ino contains zero raw ESP-platform conditionals; all gates use HAS_WEATHER_FORECAST
+- [ ] #2 SATble.ino file-level guard reads #if HAS_SAT_BLE not #if defined(ESP32)
+- [ ] #3 restAPI.ino runtime.heap_* JSON fields publish unconditionally via platformFreeHeap/platformMinFreeHeap/platformMaxFreeBlock/platformHeapFragmentation - no #if defined(ESP32) around lines 1640
+- [ ] #4 handleDebug.ino heap diagnostics block uses platform*() shims; the #if defined(ESP32) around lines 26-33 is removed
+- [ ] #5 OLED.ino:279 calls platformFreeHeap()
+- [ ] #6 MQTTstuff.ino:1922 calls platformFreeHeap()
+- [ ] #7 python build.py --firmware exits 0
+- [ ] #8 python evaluate.py --quick exits 0 and the abstraction guardrail violation count has dropped by at least 15 versus the baseline in the audit doc
+<!-- AC:END -->

--- a/backlog/tasks/task-742 - ESP-abstraction-Tier-2-unify-SATtypes-struct-fields-and-add-no-op-SAT-BLE-stubs-for-ESP8266.md
+++ b/backlog/tasks/task-742 - ESP-abstraction-Tier-2-unify-SATtypes-struct-fields-and-add-no-op-SAT-BLE-stubs-for-ESP8266.md
@@ -1,0 +1,31 @@
+---
+id: TASK-742
+title: >-
+  ESP abstraction Tier 2: unify SATtypes struct fields and add no-op SAT-BLE
+  stubs for ESP8266
+status: To Do
+assignee: []
+created_date: '2026-05-28 08:28'
+labels:
+  - esp-abstraction-audit
+  - refactor
+dependencies: []
+ordinal: 69000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Eliminate the struct-field divergence that cascades into ~10 downstream debug/REST/MQTT sites. (a) In SATtypes.h, remove the #if defined(ESP32) guards at lines 335-344 (state.sat BLE fields) and 461-475 (settings.sat BLE fields). Either keep the fields unconditionally and zero-init on ESP8266 (preferred for binary settings.json compatibility), or hoist the whole header under #if HAS_SAT. (b) Provide empty inline stubs in platform_esp8266.h for satBLEInit, satBLELoop, satBLEPublishMQTT, satBLESendStatusJSON, satBLEGetTemp, etc., so every caller can drop its #if defined(ESP32). Then strip those guards from: OTGW-firmware.ino:644, OTGW-firmware.h:284-313, SATcontrol.ino:975/1948/2559/3042, networkStuff.ino:514/530, handleDebug.ino:184/236/257/298/401, settingStuff.ino:384/1002 (factor BLE settings I/O into platformSerializeBleSettings/platformParseBleSettings). Depends on Tier 1.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 SATtypes.h has no inner #if defined(ESP32) guards inside struct definitions
+- [ ] #2 settings.json round-trips between ESP8266 and ESP32 binaries without loss of BLE fields (BLE fields are zero/empty on ESP8266 but present)
+- [ ] #3 platform_esp8266.h declares inline no-op stubs for the full satBLE* API surface
+- [ ] #4 All ESP32-feature-call sites listed in the task description no longer carry a raw ESP32 ifdef
+- [ ] #5 BLE settings serialise/parse via platformSerializeBleSettings / platformParseBleSettings - settingStuff.ino has no inner BLE ifdef
+- [ ] #6 python build.py --firmware exits 0 on both platforms
+- [ ] #7 Guardrail violation count drops by at least another 15 from Tier 1 baseline
+<!-- AC:END -->

--- a/backlog/tasks/task-743 - ESP-abstraction-Tier-3-move-per-platform-tuning-constants-into-platform_-.h-and-add-the-new-shim-set.md
+++ b/backlog/tasks/task-743 - ESP-abstraction-Tier-3-move-per-platform-tuning-constants-into-platform_-.h-and-add-the-new-shim-set.md
@@ -1,0 +1,30 @@
+---
+id: TASK-743
+title: >-
+  ESP abstraction Tier 3: move per-platform tuning constants into platform_*.h
+  and add the new shim set
+status: To Do
+assignee: []
+created_date: '2026-05-28 08:28'
+labels:
+  - esp-abstraction-audit
+  - refactor
+dependencies: []
+ordinal: 70000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+(a) Move per-platform sizing/timing constants out of application .ino files into platform_esp8266.h / platform_esp32.h: SAT_WIN4H_SIZE (SATtypes.h:100), SAT_FLOW_SAMPLE_SIZE (SATcycles.ino:62), flow index types (SATcycles.ino:68/164), SAT_TAIL_SAMPLE_SIZE (SATcycles.ino:79), HCR_DAYS (SATcycles.ino:139), HCR_INTRADAY_SIZE (SATcycles.ino:146), SAT_CYCLES_FILE_BUF_SIZE (SATcycles.ino:1115), MQTT_DISCOVERY_HEAP_MIN (MQTTstuff.ino:57), STATUS_BURST_COOLDOWN_MS (MQTTstuff.ino:136). (b) Add new platform shims and replace their callers: platformSetLed/platformBlinkLed (OTGW-firmware.ino:247-307 LED block), platformRestTxAppend/Reset/Flush/AppendProgmem (jsonStuff.ino:191-263), platformHeapHasPressure/platformHeapIsHealthyForRestore (MQTTstuff.ino:1898-1924), platformWiFiIsEncrypted (restAPI.ino:1942), platformWiFiClientConfigureSync (MQTTstuff.ino:588), platformStartNTP (networkStuff.ino:610-624 hostname workaround), platformGetResetReasonChar (OTDirect.ino:3076), platformPicSerialBegin (OTGWSerial.cpp:835-847), platformRandom (SATmqttPublish.h:46/63), platformGetMacU64 (Ethernet.ino:42, optional symmetry). Depends on Tier 2.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 All tuning constants listed are defined in platform_*.h, not in application .ino files
+- [ ] #2 All new shims in the (b) list are declared in both platform_esp8266.h and platform_esp32.h with appropriate per-platform bodies (stub or real)
+- [ ] #3 All caller sites listed are rewritten to call the shim and contain no ESP-platform ifdef
+- [ ] #4 OTGWSerial library constructor uses platformPicSerialBegin and has no #if defined(ESP8266)/(ESP32)
+- [ ] #5 python build.py --firmware exits 0 on both platforms
+- [ ] #6 Guardrail violation count drops to under 5 (board-macro references in boards.h dispatch logic only)
+<!-- AC:END -->

--- a/backlog/tasks/task-744 - ESP-abstraction-Tier-4-OLED-FreeRTOS-coupling-refactor-behind-platform-shims.md
+++ b/backlog/tasks/task-744 - ESP-abstraction-Tier-4-OLED-FreeRTOS-coupling-refactor-behind-platform-shims.md
@@ -1,0 +1,27 @@
+---
+id: TASK-744
+title: 'ESP abstraction Tier 4: OLED FreeRTOS-coupling refactor behind platform shims'
+status: To Do
+assignee: []
+created_date: '2026-05-28 08:29'
+labels:
+  - esp-abstraction-audit
+  - refactor
+dependencies: []
+ordinal: 71000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+OLED.ino currently references QueueHandle_t, xQueueCreate, xQueueReceive, IRAM_ATTR, gpio_set_intr_type, esp_timer_get_time etc. directly. Today this compiles only because HAS_OLED_CAPABLE is ESP32-only - but the inner #if defined(ESP32) checks at lines 42, 81, 91, 425, 452 contradict the abstraction principle. Introduce: PlatformOledButtonQueue type alias in platform_*.h; platformOledInitButton(pin, isrFn) (real impl on ESP32, simple pinMode on ESP8266); platformOledDrainButton(int64_t&) (real impl on ESP32, returns false on ESP8266). Move the ISR definition itself out of OLED.ino into platform_esp32.h (or a new platform_oled_esp32 sidecar). Depends on Tier 3.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 OLED.ino contains no #if defined(ESP32) blocks - all platform-specific button/ISR/queue logic dispatches through platform shims
+- [ ] #2 platform_esp32.h owns the ISR definition and FreeRTOS queue ops
+- [ ] #3 platform_esp8266.h provides safe no-op equivalents (returning false / pinMode fallback)
+- [ ] #4 OLED.ino:42 ESP32-specific includes are gone (moved into platform_esp32.h)
+- [ ] #5 python build.py --firmware exits 0
+<!-- AC:END -->

--- a/backlog/tasks/task-745 - ESP-abstraction-Tier-5-resolve-jsonStuff-int-int32-overload-ambiguity-without-per-platform-ifdefs.md
+++ b/backlog/tasks/task-745 - ESP-abstraction-Tier-5-resolve-jsonStuff-int-int32-overload-ambiguity-without-per-platform-ifdefs.md
@@ -1,0 +1,27 @@
+---
+id: TASK-745
+title: >-
+  ESP abstraction Tier 5: resolve jsonStuff int/int32 overload ambiguity without
+  per-platform ifdefs
+status: To Do
+assignee: []
+created_date: '2026-05-28 08:29'
+labels:
+  - esp-abstraction-audit
+  - refactor
+dependencies: []
+ordinal: 72000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+jsonStuff.ino:389, 487, 660 define extra sendJsonMapEntry(int) / (unsigned int) overloads only on ESP32 because xtensa-esp32 distinguishes int (32-bit) from int32_t (also 32-bit but defined as long). Three resolution paths: (1) Cast all caller sites to int32_t/uint32_t explicitly so the platform-specific overloads disappear (preferred but ~50 callsite touches). (2) Wrap the overloads in a JSON_INT_OVERLOADS_NEEDED macro set per-platform inside platform_*.h - moves the conditional into the abstraction tier. (3) Refactor sendJsonMapEntry into a template (most invasive). Pick the cleanest option after a quick survey of callsite count. Depends on Tier 3.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 jsonStuff.ino has no #if defined(ESP32) guard around the ambiguity-overload definitions
+- [ ] #2 Resolution approach is documented in an ADR if the strategy isn't obvious from the diff
+- [ ] #3 python build.py --firmware exits 0 on both platforms; no warnings about ambiguous overload resolution
+<!-- AC:END -->

--- a/backlog/tasks/task-746 - ESP-abstraction-Tier-6-promote-platform.h-boards.h-platform_-.h-into-src-libraries-Platform.md
+++ b/backlog/tasks/task-746 - ESP-abstraction-Tier-6-promote-platform.h-boards.h-platform_-.h-into-src-libraries-Platform.md
@@ -1,0 +1,29 @@
+---
+id: TASK-746
+title: >-
+  ESP abstraction Tier 6: promote platform.h / boards.h / platform_*.h into
+  src/libraries/Platform/
+status: To Do
+assignee: []
+created_date: '2026-05-28 08:29'
+labels:
+  - esp-abstraction-audit
+  - refactor
+dependencies: []
+ordinal: 73000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Today the platform abstraction lives in src/OTGW-firmware/ as application-tier neighbour headers. Promote them into a real library at src/libraries/Platform/ (with library.properties) so the boundary is physical, not just nominal. Application code includes <Platform.h> instead of platform.h. Verify the relocated files still work for both compilation paths (Arduino IDE concat + PlatformIO if used). Update the abstraction guardrail in evaluate.py to allowlist src/libraries/Platform/ as the new home. This is purely structural - no logic changes. Depends on Tier 5.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 src/libraries/Platform/ exists with platform.h, platform_esp8266.h, platform_esp32.h, boards.h and a minimal library.properties
+- [ ] #2 All application code includes through the library path (no relative #include from src/OTGW-firmware)
+- [ ] #3 evaluate.py guardrail allowlist updated to src/libraries/Platform/*.h instead of src/OTGW-firmware/platform*.h
+- [ ] #4 python build.py --firmware exits 0 on both platforms
+- [ ] #5 An ADR documents the move and the abstraction-layer contract
+<!-- AC:END -->

--- a/docs/audits/2026-05-28-esp-abstraction-leak-audit.md
+++ b/docs/audits/2026-05-28-esp-abstraction-leak-audit.md
@@ -1,0 +1,238 @@
+# ESP Abstraction Leak Audit — feature-dev-2.0.0-otgw32-esp32-sat-support
+
+**Date:** 2026-05-28
+**Auditor:** Claude (senior C++/ESP IoT review pass, on behalf of @rvdbreemen)
+**Branch audited:** `feature-dev-2.0.0-otgw32-esp32-sat-support` @ `9be88a0d`
+**Backlog:** TASK-739 (this deliverable) → TASK-740…746 (Tier 0–6 remediation)
+
+## 1. Purpose
+
+The 2.0.0 branch carries an explicit ESP8266/ESP32 abstraction layer so that
+application code can be written against `platformXxx()` shims and `HAS_*`
+capability flags, never against raw `ESP8266` / `ESP32` /
+`ARDUINO_ARCH_ESP*` / `BOARD_NODOSHOP_ESP*` preprocessor symbols. The
+contract is that *no* such conditional exists outside the abstraction-layer
+files. This audit measures the gap.
+
+## 2. Abstraction layer files (allowed to contain platform `#ifdef`)
+
+| File | Role |
+|---|---|
+| `src/OTGW-firmware/platform.h` | dispatcher → selects platform header |
+| `src/OTGW-firmware/platform_esp8266.h` | ESP8266 includes, shims, type aliases |
+| `src/OTGW-firmware/platform_esp32.h` | ESP32 includes, shims, type aliases |
+| `src/OTGW-firmware/boards.h` | pin maps + `HAS_*` capability flags |
+| `src/OTGW-firmware/OTGW-ModUpdateServer{.h,-esp32.h,-impl.h}` | parallel mini-abstraction (dispatcher + per-platform impl) for the HTTP update server |
+
+Anything else is application code and must not branch on the platform.
+
+## 3. Baseline
+
+**78 violations across 18 files** as of 2026-05-28 / commit `9be88a0d`.
+
+| Count | File |
+|---:|---|
+| 12 | `src/OTGW-firmware/SATweather.ino` |
+| 8 | `src/OTGW-firmware/SATcycles.ino` |
+| 8 | `src/OTGW-firmware/jsonStuff.ino` |
+| 8 | `src/OTGW-firmware/restAPI.ino` |
+| 6 | `src/OTGW-firmware/MQTTstuff.ino` |
+| 6 | `src/OTGW-firmware/handleDebug.ino` |
+| 5 | `src/OTGW-firmware/OLED.ino` |
+| 4 | `src/OTGW-firmware/SATcontrol.ino` |
+| 4 | `src/OTGW-firmware/networkStuff.ino` |
+| 3 | `src/OTGW-firmware/OTGW-firmware.h` |
+| 3 | `src/OTGW-firmware/SATtypes.h` |
+| 2 | `src/OTGW-firmware/OTGW-firmware.ino` |
+| 2 | `src/OTGW-firmware/SATmqttPublish.h` |
+| 2 | `src/OTGW-firmware/settingStuff.ino` |
+| 2 | `src/libraries/OTGWSerial/OTGWSerial.cpp` |
+| 1 | `src/OTGW-firmware/OTDirect.ino` |
+| 1 | `src/OTGW-firmware/SATble.ino` |
+| 1 | `src/OTGW-firmware/helperStuff.ino` |
+
+`evaluate.py` enforces this baseline via the `check_esp_abstraction_boundary()` gate.
+The check FAILs if the count rises and WARNs while any violation remains.
+When the count reaches zero the gate becomes a permanent invariant.
+
+## 4. Findings grouped by remediation pattern
+
+Grouped this way because one fix often kills many violations.
+
+### A. Whole-module feature files pretending to be platform modules — HIGH
+
+These files exist *because* the feature is ESP32-only. Wrap them with **one
+feature flag** at the top, drop every inner `#ifdef`:
+
+| File | Inner ESP-conditionals | Suggested gate (`boards.h`) |
+|---|---:|---|
+| `SATble.ino` | 1 (file-level, line 24) | `HAS_SAT_BLE` |
+| `SATweather.ino` | 11 (lines 35, 63, 176, 192, 223, 228, 275, 396, 579, 612, 687, 701) | `HAS_WEATHER_FORECAST` (independent of SAT) |
+| `Ethernet.ino` | already gated by `HAS_ETH_CAPABLE` | model for the others |
+
+`SATweather.ino` is the worst offender: it has 11 *individual* `#ifndef
+ESP8266` blocks inside one file. Replace them with one outer `#if
+HAS_WEATHER_FORECAST` and let the dead code disappear cleanly.
+
+→ Tackled by **Tier 1** (TASK-741).
+
+### B. Struct-field divergence in shared headers — HIGH (schema hazard)
+
+| File:line | What diverges | Risk |
+|---|---|---|
+| `SATtypes.h:335-344` | `state.sat.SATRuntimeSection` BLE fields only exist on ESP32 | Code reading these fields must replicate the `#ifdef`, multiplying leaks |
+| `SATtypes.h:461-475` | Persistent `OTGWSettings.sat` BLE fields only exist on ESP32 | `settings.json` no longer round-trips between platforms — silent data loss |
+
+Fix: either (a) include the fields unconditionally and zero them on ESP8266
+— the 30-byte RAM / 220-byte flash cost is trivial — or (b) hoist
+`SATtypes.h` itself under `#if HAS_SAT`. Whichever you pick, every
+downstream `#if defined(ESP32)` in category **F** below collapses to
+nothing.
+
+→ Tackled by **Tier 2** (TASK-742).
+
+### C. Per-platform tuning constants scattered through `.ino` files — LOW (quick win)
+
+| Constant | Site | Belongs in |
+|---|---|---|
+| `SAT_WIN4H_SIZE` | `SATtypes.h:100-104` | `platform_*.h` |
+| flow sample sizes | `SATcycles.ino:47/62/68/79` | `platform_*.h` |
+| `HCR_DAYS` / `HCR_INTRADAY_SIZE` / index types | `SATcycles.ino:139/146/164` | `platform_*.h` |
+| `SAT_CYCLES_FILE_BUF_SIZE` | `SATcycles.ino:1115` | `platform_*.h` |
+| `MQTT_DISCOVERY_HEAP_MIN` | `MQTTstuff.ino:57-61` | `platform_*.h` |
+| `STATUS_BURST_COOLDOWN_MS` | `MQTTstuff.ino:136-140` | `platform_*.h` |
+
+Pattern is always `#if defined(ESP8266) define X 30 #else define X 360
+#endif`. Move both arms to the appropriate `platform_*.h`; the application
+file just consumes `X`.
+
+→ Tackled by **Tier 3** (TASK-743).
+
+### D. Missing shims for divergent APIs — MEDIUM-HIGH
+
+These need one new `platformXxx()` function per pair. After they exist,
+the caller is one line, unguarded.
+
+| Capability | Sites | Proposed shim |
+|---|---|---|
+| LED PWM/GPIO | `OTGW-firmware.ino:247-307` (60-line block, `BOARD_NODOSHOP_ESP32` guarded) | `platformSetLed(led,status)` / `platformBlinkLed(led)` |
+| JSON tx coalescing | `jsonStuff.ino:191-263` (5 sites) | `platformRestTxAppend/Reset/Flush/AppendProgmem()` |
+| Heap-health predicate | `MQTTstuff.ino:1898-1924` (also bypasses shim with raw `ESP.getFreeHeap()` at :1922) | `platformHeapHasPressure()` / `platformHeapIsHealthyForRestore()` |
+| WiFi encryption enum | `restAPI.ino:1942` | `platformWiFiIsEncrypted(uint8_t)` |
+| WiFi-client setSync | `MQTTstuff.ino:588` | `platformWiFiClientConfigureSync(WiFiClient&)` |
+| NTP / hostname-reset workaround | `networkStuff.ino:610-624` | `platformStartNTP()` (encapsulates the SDK bug) |
+| Reset reason → PIC char | `OTDirect.ino:3076-3086` | `platformGetResetReasonChar()` |
+| HardwareSerial(PIC) begin | `OTGWSerial.cpp:835-847` (first-party lib) | `platformPicSerialBegin(serial)` |
+| Random source | `SATmqttPublish.h:46/63` | `platformRandom()` |
+
+→ Tackled by **Tier 3** (TASK-743).
+
+### E. Missing stubs for ESP32-only feature functions — MEDIUM
+
+Once category **A** is in place with `HAS_SAT_BLE`, also declare empty
+inline stubs for the SAT-BLE API in `platform_esp8266.h` (or in a
+`HAS_SAT_BLE`-guarded header). Each call site then drops its `#if
+defined(ESP32)`. Affected sites:
+
+- `OTGW-firmware.ino:644` — `satBLELoop()`
+- `OTGW-firmware.h:284-313` — forward declarations
+- `SATcontrol.ino:975/1948/2559/3042` — `satBLEGetTemp / satBLESendStatusJSON / satBLEPublishMQTT / satBLEInit`
+- `settingStuff.ino:384-401` and `:1002-…` — BLE settings serialize/parse (extract to `platformSerializeBleSettings` / `platformParseBleSettings`)
+- `networkStuff.ino:514-539` — debug telemetry / menu items
+- `handleDebug.ino:26, 184, 236, 257, 298, 401` — heap+BLE+menu+key handler
+
+→ Tackled by **Tier 2** (TASK-742).
+
+### F. Application code reading board macros directly — LOW
+
+| Site | Issue |
+|---|---|
+| `OTGW-firmware.ino:247` | `#if defined(BOARD_NODOSHOP_ESP32)` for LED block — disappears once `platformSetLed()` exists. |
+| `OTGW-firmware.h:543-551` | `boardName()` switches on `BOARD_NODOSHOP_*` — replace with `#define BOARD_NAME_PROGMEM "..."` per board in `boards.h`. |
+
+→ Tackled by **Tier 3** (TASK-743) — falls out of the LED shim work.
+
+### G. OLED FreeRTOS coupling — MEDIUM (latent)
+
+`OLED.ino:42, 81, 91, 425, 452` uses `QueueHandle_t`, `xQueueCreate`,
+`xQueueReceive`, `gpio_set_intr_type`, `IRAM_ATTR`, `esp_timer_get_time`
+etc. directly. Today this compiles only because `HAS_OLED_CAPABLE` is
+ESP32-only — but the *inner* `#if defined(ESP32)` checks are belt-and-
+braces that contradict the principle. If an ESP8266 board ever gains an
+OLED, all of `OLED.ino` breaks. Fix now via `platformOledInitButton(pin,
+isrFn)` / `platformOledDrainButton(int64_t&)` shims; move the ISR + queue
+into `platform_esp32.h`.
+
+→ Tackled by **Tier 4** (TASK-744).
+
+### H. Bypassing existing shims with raw `ESP.getXxx()` — LOW per site, quietly corrosive
+
+These sites have an available `platformXxx()` shim and ignore it. No
+`#ifdef` is even needed — just a substitution:
+
+| File:line | Wrong | Right |
+|---|---|---|
+| `restAPI.ino:1639` | `ESP.getFreeHeap()` | `platformFreeHeap()` |
+| `restAPI.ino:1641/1642` | `ESP.getMinFreeHeap()` / `getMaxAllocHeap()` | `platformMinFreeHeap()` / `platformMaxFreeBlock()` |
+| `restAPI.ino:1644` | `ESP.getHeapFragmentation()` | `platformHeapFragmentation()` |
+| `restAPI.ino:1646` | `ESP.getMaxFreeBlockSize()` | `platformMaxFreeBlock()` |
+| `handleDebug.ino:25/27/28/30/32` | mixed `ESP.*` heap APIs inside an `#ifdef` block | call shims, drop the `#ifdef` |
+| `OLED.ino:279` | `ESP.getFreeHeap()` | `platformFreeHeap()` |
+| `MQTTstuff.ino:1922` | `ESP.getFreeHeap()` (inside the ESP8266 arm of a heap predicate) | `platformFreeHeap()` |
+| `OTGW-ModUpdateServer-impl.h:195` | `ESP.getFreeSketchSpace()` | acceptable — this file is ESP8266-only by dispatch |
+| `Ethernet.ino:42` | `ESP.getEfuseMac()` | acceptable — file is `HAS_ETH_CAPABLE`-gated and ESP32-only; could still go through a `platformGetMacU64()` shim for symmetry |
+
+→ Tackled by **Tier 1** (TASK-741) — quick `sed`-level wins.
+
+### I. Type-ambiguity overloads — LOW (defensible)
+
+`jsonStuff.ino:389, 487, 660` define extra `sendJsonMapEntry(int)` /
+`(unsigned int)` overloads on ESP32 because xtensa-esp32 distinguishes
+`int` from `int32_t` (a `long` there). Three resolution paths:
+
+1. Cast all call sites to `int32_t/uint32_t` explicitly — eliminates the
+   overloads and the `#ifdef` (preferred, ~50 callsite edits).
+2. Wrap the overloads in a `JSON_INT_OVERLOADS_NEEDED` macro set per-
+   platform inside `platform_*.h` — moves the conditional into the
+   abstraction tier without changing call sites.
+3. Refactor `sendJsonMapEntry` into a template (most invasive).
+
+→ Tackled by **Tier 5** (TASK-745).
+
+## 5. Prioritised remediation roadmap
+
+| Tier | Task | Action | Eliminates | Effort |
+|---|---|---|---:|---|
+| **0** | TASK-740 | Add `HAS_SAT_BLE`, `HAS_WEATHER_FORECAST`, `HAS_SAT` flags to `boards.h` | infra for tiers 1-3 | 30 min |
+| **1** | TASK-741 | Collapse `SATweather.ino`'s 11 `#ifndef ESP8266` to one `#if HAS_WEATHER_FORECAST`; flip `SATble.ino` file guard to `#if HAS_SAT_BLE`; substitute raw `ESP.getXxx()` → existing shims | ~22 sites | 2 hr |
+| **2** | TASK-742 | Unify `SATtypes.h` struct fields; add no-op SAT-BLE stubs in `platform_esp8266.h`; strip all `#if defined(ESP32)` from SAT-BLE call sites; factor BLE settings I/O | ~15 sites | half day |
+| **3** | TASK-743 | Move tuning constants into `platform_*.h`; build all new shims (LED, NTP, reset-reason, WiFi enum, JSON tx, heap pressure, PIC serial, etc.) | ~15 sites | 1 day |
+| **4** | TASK-744 | OLED platform-shim refactor (queue, ISR, drain) | 5 sites | half day |
+| **5** | TASK-745 | Resolve `jsonStuff.ino` overload ambiguity | 3 sites | half day |
+| **6** | TASK-746 | Promote `platform.h` / `boards.h` / `platform_*.h` into `src/libraries/Platform/` so the boundary is physical, not nominal; ADR documenting the contract | structural | 1 day |
+
+After Tier 3 the violation count should be **under 5** (residual
+`BOARD_NODOSHOP_ESP*` dispatch logic inside `boards.h` itself). After
+Tier 6 the count is zero and the gate becomes a permanent invariant.
+
+## 6. Guardrail
+
+`evaluate.py` gains `check_esp_abstraction_boundary()` (TASK-739):
+
+- WARN whenever the violation count is non-zero (visible cost).
+- FAIL whenever the count rises above the baseline (regression gate).
+- PASS at zero.
+
+Baseline is encoded as `ESP_ABSTRACTION_BASELINE = 78` in `evaluate.py`.
+Each tier task must update the constant downward as part of its DoD.
+
+The same regex is documented in `CLAUDE.md` and `AGENTS.md` so new code
+written by humans or agents is shaped to clear the gate before commit.
+
+## 7. References
+
+- TASK-739 (this deliverable) and TASK-740…746 (tier remediation)
+- `src/OTGW-firmware/platform.h` and the rest of the abstraction layer
+- `evaluate.py::check_esp_abstraction_boundary()`
+- `CLAUDE.md` § Critical Coding Rules → ESP Platform Abstraction
+- `AGENTS.md` § Architecture rules → ESP Platform Abstraction

--- a/evaluate.py
+++ b/evaluate.py
@@ -493,6 +493,73 @@ def otdirect_25238_bridge_regressions(
     }
 
 
+# === ESP abstraction boundary (TASK-739) =================================
+#
+# The 2.0.0 branch carries an explicit ESP8266/ESP32 abstraction layer
+# (platform.h + platform_esp*.h + boards.h + the OTGW-ModUpdateServer trio).
+# Application code MUST NOT branch on raw ESP8266 / ESP32 / ARDUINO_ARCH_ESP*
+# / BOARD_NODOSHOP_ESP* preprocessor symbols — that work belongs in the
+# abstraction headers, called from application code via platformXxx() shims
+# or gated by HAS_* capability flags from boards.h.
+#
+# Baseline ratchet: ESP_ABSTRACTION_BASELINE is the maximum tolerated count
+# of violating sites. The gate FAILs above the baseline (regression) and
+# WARNs while any violation remains. Each remediation tier task
+# (TASK-740..746) must lower the baseline as part of its DoD.
+
+ESP_ABSTRACTION_ALLOWED_FILES: Tuple[str, ...] = (
+    "src/OTGW-firmware/platform.h",
+    "src/OTGW-firmware/platform_esp8266.h",
+    "src/OTGW-firmware/platform_esp32.h",
+    "src/OTGW-firmware/boards.h",
+    "src/OTGW-firmware/OTGW-ModUpdateServer.h",
+    "src/OTGW-firmware/OTGW-ModUpdateServer-esp32.h",
+    "src/OTGW-firmware/OTGW-ModUpdateServer-impl.h",
+)
+
+# Baseline as of 2026-05-28 / commit 9be88a0d. See
+# docs/audits/2026-05-28-esp-abstraction-leak-audit.md.
+ESP_ABSTRACTION_BASELINE: int = 78
+
+_ESP_PLATFORM_PP_RE = re.compile(
+    r'^\s*#\s*(?:if|ifdef|ifndef|elif)\b.*\b'
+    r'(?:ESP8266|ESP32|ARDUINO_ARCH_ESP8266|ARDUINO_ARCH_ESP32'
+    r'|BOARD_NODOSHOP_ESP[A-Za-z0-9_]*)\b'
+)
+
+
+def scan_esp_abstraction_violations(project_dir: Path) -> List[str]:
+    """Return a sorted list of "<relpath>:<line>: <text>" entries for every
+    preprocessor directive outside the abstraction allowlist that branches on
+    a raw ESP platform symbol. Walks src/OTGW-firmware/ (*.ino, *.cpp, *.h
+    excluding the auto-generated *.ino.cpp) and src/libraries/ (*.cpp, *.h)."""
+    allowed = {(project_dir / p).resolve() for p in ESP_ABSTRACTION_ALLOWED_FILES}
+    firmware = project_dir / "src" / "OTGW-firmware"
+    libraries = project_dir / "src" / "libraries"
+
+    files: List[Path] = []
+    files.extend(firmware.glob("*.ino"))
+    files.extend(f for f in firmware.glob("*.cpp") if not f.name.endswith(".ino.cpp"))
+    files.extend(firmware.glob("*.h"))
+    if libraries.exists():
+        files.extend(libraries.rglob("*.cpp"))
+        files.extend(libraries.rglob("*.h"))
+
+    violations: List[str] = []
+    for f in sorted(files):
+        if f.resolve() in allowed:
+            continue
+        try:
+            text = f.read_text(encoding="utf-8", errors="ignore")
+        except OSError:
+            continue
+        for i, line in enumerate(text.splitlines(), 1):
+            if _ESP_PLATFORM_PP_RE.match(line):
+                rel = f.relative_to(project_dir).as_posix()
+                violations.append(f"{rel}:{i}: {line.strip()[:80]}")
+    return violations
+
+
 class Colors:
     """ANSI color codes"""
     HEADER = '\033[95m'
@@ -2606,6 +2673,44 @@ class WorkspaceEvaluator:
 
     # ===== BINARY-SAFE COMPARE CHECK =====
 
+    def check_esp_abstraction_boundary(self):
+        """ESP platform abstraction boundary (TASK-739).
+
+        The 2.0.0 branch isolates all ESP8266/ESP32 conditional code behind a
+        platform abstraction layer (platform*.h, boards.h, OTGW-ModUpdateServer
+        trio). This check counts preprocessor sites outside that allowlist
+        that branch on raw ESP platform symbols. The count must never rise
+        above the recorded baseline; the baseline ratchets down task by task
+        as remediation tiers complete (TASK-740..746). See
+        docs/audits/2026-05-28-esp-abstraction-leak-audit.md."""
+        print(f"\n{Colors.BOLD}{Colors.OKBLUE}=== ESP Abstraction Boundary ==={Colors.ENDC}")
+
+        violations = scan_esp_abstraction_violations(self.project_dir)
+        n = len(violations)
+        baseline = ESP_ABSTRACTION_BASELINE
+        details_head = "; ".join(violations[:8])
+
+        if n == 0:
+            self.add_result(EvaluationResult(
+                "Architecture", "ESP abstraction boundary", "PASS",
+                "No platform-conditional code outside the abstraction layer",
+            ))
+        elif n > baseline:
+            self.add_result(EvaluationResult(
+                "Architecture", "ESP abstraction boundary", "FAIL",
+                f"Regression: {n} platform-conditional sites (baseline {baseline}). "
+                f"New code must use platformXxx() shims or HAS_* board flags from boards.h.",
+                details_head,
+            ))
+        else:
+            self.add_result(EvaluationResult(
+                "Architecture", "ESP abstraction boundary", "WARN",
+                f"{n} platform-conditional sites outside abstraction layer "
+                f"(baseline {baseline}, target 0). Lower ESP_ABSTRACTION_BASELINE "
+                f"after each remediation tier task (TASK-740..746).",
+                details_head,
+            ))
+
     def check_binary_safe_compare(self):
         """INFO: flag every strncmp_P / strstr_P call site. These MUST operate on
         null-terminated text only; running them against binary buffers triggers
@@ -2790,6 +2895,7 @@ class WorkspaceEvaluator:
         self.check_progmem_compliance()
         self.check_no_arduinojson()
         self.check_binary_safe_compare()
+        self.check_esp_abstraction_boundary()       # ESP abstraction guardrail (TASK-739)
         self.check_otdirect_25238_bridge()
         self.check_adr102_otbus_liveness_topic()     # ADR-102 CI gate (TASK-623)
         self.check_sat_publishes_use_helpers()       # ADR-111 CI gate (TASK-722)


### PR DESCRIPTION
## Summary

Persists the senior-IoT audit of the ESP8266/ESP32 abstraction layer on the 2.0.0 branch and locks in a guardrail so the abstraction can only get cleaner over time.

- **Audit document** — `docs/audits/2026-05-28-esp-abstraction-leak-audit.md` enumerates **78 platform-conditional sites across 18 files** outside the allowlisted abstraction headers (`platform.h`, `platform_esp*.h`, `boards.h`, `OTGW-ModUpdateServer` trio), grouped by remediation pattern with file:line references.
- **evaluate.py guardrail** — new `check_esp_abstraction_boundary()` with a baseline ratchet: **FAIL** on regression above `ESP_ABSTRACTION_BASELINE` (currently 78), **WARN** while any violation remains, **PASS** at zero. Wired into the essential-checks block (runs in `--quick` mode too).
- **CLAUDE.md / AGENTS.md** — matching `ESP Platform Abstraction` section in each, stating the rule and naming the four required behaviours (use `platformXxx()` shims; gate features with `HAS_*` flags from `boards.h`; never reference raw `BOARD_NODOSHOP_ESP*` outside `boards.h`; never call `ESP.getXxx()` when a shim exists).
- **Tiered remediation tasks** — `TASK-740`..`TASK-746` (Tier 0…6), each scoped to a single theme. Tier 1 alone removes ~22 sites; through Tier 3 the count drops under 5.

## Files touched

```
 AGENTS.md                                          +15 lines
 CLAUDE.md                                          +52 lines
 evaluate.py                                       +106 lines
 docs/audits/2026-05-28-esp-abstraction-leak-audit.md  (new)
 backlog/tasks/task-739..task-746                    (new, 8 tasks)
```

No firmware C/C++ touched. The 2.0.0 abstraction headers themselves are unchanged.

## Test plan

- [x] `python3 evaluate.py --quick` — 64 PASS / 1 WARN (the new gate, at baseline 78) / 0 FAIL / 7 INFO; health 98.6%; exit 0.
- [x] Regression-gate sanity check: with `ESP_ABSTRACTION_BASELINE` simulated at 77 while count is 78, the gate FAILs with the expected message.
- [x] `scan_esp_abstraction_violations()` returns the documented 78 entries across the documented 18 files.
- [ ] `python build.py --firmware` — cannot run in this sandbox (outbound SSL to github.com blocked for `esp32-3.3.5.tar.xz` toolchain fetch). Changes are docs + Python-lint only with no firmware C/C++ touched, so per CLAUDE.md push policy ("docs-only commits ... may skip both gates — they cannot affect firmware compilation") this is acceptable. Please confirm a clean local build before merging.
- [ ] Reviewer skim of the audit doc against `docs/audits/2026-05-28-esp-abstraction-leak-audit.md` to confirm tier sequencing matches your priorities.

## Notes

- Commit landed **unsigned** because the sandbox signing server returned a persistent 400 (`"missing source"`) across three attempts. User authorised a one-time bypass; the PR will lack the *Verified* badge on this commit only.
- Each remediation tier task (TASK-740..746) carries an AC obliging the executor to lower `ESP_ABSTRACTION_BASELINE` in `evaluate.py` as part of its Definition of Done, so the count can only ratchet downward.

https://claude.ai/code/session_01JXqotakBaNsVZ8JNxPa5KX

---
_Generated by [Claude Code](https://claude.ai/code/session_01JXqotakBaNsVZ8JNxPa5KX)_