### PR TITLE
fix(esp8266): mechanical memory trims (PR A) — reclaim ~3.4 KB static DRAM

### DIFF
--- a/evaluate.py
+++ b/evaluate.py
@@ -1230,6 +1230,113 @@ class WorkspaceEvaluator:
                 detail
             ))
 
+    # ===== ESP8266 STATIC-DRAM GUARDS (memory audit, PR #644) =====
+
+    def check_no_settings_state_snapshots(self):
+        """Catch regression of the _noopSnapshot anti-pattern.
+
+        Any ``static OTGWSettings <name>`` or ``static OTGWState <name>``
+        declaration outside the canonical global definitions in
+        ``OTGW-firmware.h`` is a multi-KB DRAM consumer on ESP8266 (one
+        full struct copy per declaration). The audit's "Trim 1"
+        eliminated the original instance in ``settingStuff.ino`` by
+        replacing the snapshot with a CRC32 sentinel. This check
+        prevents the pattern from reappearing.
+        """
+        src_dir = config.FIRMWARE_ROOT
+        pat = re.compile(
+            r"^\s*static\s+(OTGWSettings|OTGWState)\s+\w+\s*[;=]",
+            re.MULTILINE,
+        )
+        # Inline allowlist marker (any of these on the same or previous line
+        # exempts the declaration — used for the ESP32 fallback path where
+        # crc32() from ESP8266 core is not available).
+        ALLOW_MARKER = "noqa: settings-snapshot"
+        offenders: List[str] = []
+        for fn in list(src_dir.glob("*.ino")) + list(src_dir.glob("*.cpp")) + list(src_dir.glob("*.h")):
+            if fn.name == "OTGW-firmware.h":
+                continue  # canonical globals live here
+            try:
+                content = fn.read_text(encoding="utf-8", errors="ignore")
+            except OSError:
+                continue
+            lines = content.splitlines()
+            for m in pat.finditer(content):
+                line_no = content[: m.start()].count("\n") + 1
+                # Check the matched line and the two lines above for the
+                # marker (covers a short multi-line justification comment).
+                idx = line_no - 1
+                context_lines = lines[max(0, idx - 2) : idx + 1]
+                if any(ALLOW_MARKER in ln for ln in context_lines):
+                    continue
+                offenders.append(f"{fn.name}:{line_no}")
+        if offenders:
+            shown = "; ".join(offenders[:5])
+            if len(offenders) > 5:
+                shown += f"; (+{len(offenders) - 5} more)"
+            self.add_result(EvaluationResult(
+                "Memory", "settings/state snapshot copies", "FAIL",
+                f"Found {len(offenders)} `static OTGW(Settings|State)` declaration(s) outside OTGW-firmware.h",
+                shown + " — use a CRC32 sentinel instead (memory audit Trim 1)"
+            ))
+        else:
+            self.add_result(EvaluationResult(
+                "Memory", "settings/state snapshot copies", "PASS",
+                "No static OTGWSettings/OTGWState declarations outside OTGW-firmware.h"
+            ))
+
+    def check_dispatch_tables_progmem(self):
+        """Catch dispatch tables placed in .rodata (= DRAM on ESP8266).
+
+        Tables named with the ``k*`` prefix (project convention) and
+        typed as a non-trivial struct (i.e. not a char/byte/int array)
+        must carry the ``PROGMEM`` annotation, otherwise they sit in
+        ``.rodata`` which is DRAM on the ESP8266 linker layout. The
+        rows must then be dispatched via ``memcpy_P`` into stack-locals
+        before reading their fields. See ``kSatMqttCmds`` in
+        ``MQTTstuff.ino`` and ``kV2Routes`` in ``restAPI.ino`` for the
+        canonical pattern (memory audit Trim 2).
+        """
+        src_dir = config.FIRMWARE_ROOT
+        # Match: static const <StructType> k<Name>[] = { ... }   (no PROGMEM)
+        pat = re.compile(
+            r"^\s*static\s+const\s+([A-Za-z_]\w*)\s+(k[A-Za-z_]\w*)\s*\[\s*\]\s*=",
+            re.MULTILINE,
+        )
+        # Element types we deliberately skip — these are char/byte/int arrays
+        # whose string-pool placement on this linker layout is already
+        # PROGMEM-equivalent, or whose individual size is trivially small.
+        skip_types = {
+            "char", "uint8_t", "int", "uint16_t", "uint32_t",
+            "int32_t", "byte", "size_t",
+        }
+        offenders: List[str] = []
+        for fn in list(src_dir.glob("*.ino")) + list(src_dir.glob("*.cpp")):
+            try:
+                content = fn.read_text(encoding="utf-8", errors="ignore")
+            except OSError:
+                continue
+            for m in pat.finditer(content):
+                element_type = m.group(1)
+                if element_type in skip_types:
+                    continue
+                line_no = content[: m.start()].count("\n") + 1
+                offenders.append(f"{fn.name}:{line_no} {m.group(2)} ({element_type})")
+        if offenders:
+            shown = "; ".join(offenders[:5])
+            if len(offenders) > 5:
+                shown += f"; (+{len(offenders) - 5} more)"
+            self.add_result(EvaluationResult(
+                "Memory", "dispatch tables in PROGMEM", "WARN",
+                f"Found {len(offenders)} dispatch table(s) missing PROGMEM annotation",
+                shown + " — annotate `[] PROGMEM` and dispatch via memcpy_P (audit Trim 2)"
+            ))
+        else:
+            self.add_result(EvaluationResult(
+                "Memory", "dispatch tables in PROGMEM", "PASS",
+                "All k* struct-element dispatch tables are PROGMEM-annotated"
+            ))
+
     # ===== STATUS BURST TUNING (TASK-353/368) =====
 
     def check_status_burst_cooldown_bound(self):
@@ -2800,6 +2907,8 @@ class WorkspaceEvaluator:
         self.check_publishedtopic_counter_reset()     # ADR-062 CI gate (TASK-364)
         self.check_ha_sensor_index_consistency()      # HA discovery gate (TASK-392)
         self.check_json_buffer_arithmetic()           # TASK-352/368
+        self.check_no_settings_state_snapshots()      # ESP8266 memory audit PR #644 Trim 1 gate
+        self.check_dispatch_tables_progmem()          # ESP8266 memory audit PR #644 Trim 2 gate
         self.check_status_burst_cooldown_bound()      # TASK-353/368
         self.check_status_publishers_wrap_burst()     # TASK-347/354/368, ADR-088 sub-rule 1
         self.check_drip_consults_deferred()           # TASK-426, ADR-088 sub-rule 3

--- a/src/OTGW-firmware/FSexplorer.ino
+++ b/src/OTGW-firmware/FSexplorer.ino
@@ -126,8 +126,14 @@ void startWebserver(){
       httpServer.setContentLength(CONTENT_LENGTH_UNKNOWN);
       httpServer.send(200, F("text/html; charset=UTF-8"), F(""));
 
-      // Use a fixed-size line buffer instead of String to avoid heap fragmentation.
-      static char lineBuf[512];
+      // Line buffer: 512 B is sized for the longest line in index.html plus the
+      // ?v=<hash> injection slack. Stack-local (not static) because httpServer.
+      // sendContent() can yield via feedWatchDog(), which would let a re-entered
+      // sendIndex() clobber a shared static buffer mid-line. Stack peak of one
+      // extra 512 B frame per concurrent (re-entered) request is within the
+      // ESP8266 ~4 KB cooperative-scheduling budget. Saves 512 B BSS vs the
+      // previous function-static placement.
+      char lineBuf[512];
       while (f.available()) {
         int n = f.readBytesUntil('\n', lineBuf, sizeof(lineBuf) - 1);
         lineBuf[n] = '\0';

--- a/src/OTGW-firmware/MQTTstuff.ino
+++ b/src/OTGW-firmware/MQTTstuff.ino
@@ -662,8 +662,12 @@ struct SatMqttCmdEntry {
 };
 
 // Dispatch table. Terminated by a { nullptr, nullptr, nullptr } sentinel,
-// same convention as kV2Routes[] in restAPI.ino.
-static const SatMqttCmdEntry kSatMqttCmds[] = {
+// same convention as kV2Routes[] in restAPI.ino. Placed in PROGMEM so the
+// ~960 B of struct entries lives in flash, not DRAM. The string literals
+// reachable via cmd/settingKey remain in their default placement (rodata
+// .str pools, which the ESP8266 linker script maps to .irom0.text). Read
+// each row with memcpy_P in the dispatch loop below.
+static const SatMqttCmdEntry kSatMqttCmds[] PROGMEM = {
   // --- Typed handlers (payload parsing lives in the handler) ---
   { "target",                 nullptr,                _satTargetTempCmd },
   { "indoor_temp",            nullptr,                _satExtTempCmd },
@@ -757,13 +761,20 @@ static const SatMqttCmdEntry kSatMqttCmds[] = {
 };
 
 // Returns true when the sub-command was found in the table and dispatched.
+// kSatMqttCmds is PROGMEM; copy each row into a stack-local before reading
+// its fields (the pointer values inside the row point at .rodata-string-pool
+// content which is itself in flash; once memcpy'd to RAM they can be passed
+// to strcasecmp / updateSetting like any normal const char*).
 static bool dispatchSatMqttCmd(const char* cmd, const char* payload) {
-  for (const SatMqttCmdEntry* e = kSatMqttCmds; e->cmd != nullptr; e++) {
-    if (strcasecmp(cmd, e->cmd) == 0) {
-      if (e->handler) {
-        e->handler(payload);
-      } else if (e->settingKey) {
-        updateSetting(e->settingKey, payload);
+  for (size_t i = 0; ; i++) {
+    SatMqttCmdEntry e;
+    memcpy_P(&e, &kSatMqttCmds[i], sizeof(SatMqttCmdEntry));
+    if (e.cmd == nullptr) break;  // sentinel
+    if (strcasecmp(cmd, e.cmd) == 0) {
+      if (e.handler) {
+        e.handler(payload);
+      } else if (e.settingKey) {
+        updateSetting(e.settingKey, payload);
       }
       return true;
     }

--- a/src/OTGW-firmware/restAPI.ino
+++ b/src/OTGW-firmware/restAPI.ino
@@ -1987,7 +1987,12 @@ static const char kRouteDiscovery[]  PROGMEM = "discovery";
 static const char kRouteDebugDump[]  PROGMEM = "debug";
 static const char kRouteNetwork[]    PROGMEM = "network";  // TASK-585
 
-static const ApiRoute kV2Routes[] = {
+// Dispatch table placed in PROGMEM so the ~136 B of {segment, handler}
+// rows live in flash, not DRAM. Same pattern as kSatMqttCmds in
+// MQTTstuff.ino. The segment string pointers reference named PROGMEM
+// constants (kRouteHealth[] PROGMEM = "health", etc.) so they remain
+// usable with strcmp_P after the row is memcpy_P'd into a stack-local.
+static const ApiRoute kV2Routes[] PROGMEM = {
   { kRouteHealth,     handleHealth },
   { kRouteSettings,   handleSettings },
   { kRouteSensors,    handleSensors },
@@ -2062,13 +2067,16 @@ void processAPI()
         if (!checkHttpAuth()) return;
       }
 
-      // Dispatch via route table
+      // Dispatch via route table (table is PROGMEM; copy row into stack-local before reading)
       if (wc > 3) {
-        for (const ApiRoute* r = kV2Routes; r->segment != nullptr; r++) {
-          if (strcmp_P(words[3], r->segment) == 0) {
+        for (size_t i = 0; ; i++) {
+          ApiRoute r;
+          memcpy_P(&r, &kV2Routes[i], sizeof(ApiRoute));
+          if (r.segment == nullptr) break;  // sentinel
+          if (strcmp_P(words[3], r.segment) == 0) {
             restResponseStatus = 200; // default; overwritten by sendApiError if handler fails
-            r->handler(words, wc, method, originalURI);
-            RESTDebugTf(PSTR("REST %s %s => %d v2/%S %lums\r\n"), httpMethodToStr(method), originalURI, restResponseStatus, r->segment, millis() - startMs);
+            r.handler(words, wc, method, originalURI);
+            RESTDebugTf(PSTR("REST %s %s => %d v2/%S %lums\r\n"), httpMethodToStr(method), originalURI, restResponseStatus, r.segment, millis() - startMs);
             return;
           }
         }

--- a/src/OTGW-firmware/settingStuff.ino
+++ b/src/OTGW-firmware/settingStuff.ino
@@ -627,6 +627,8 @@ void updateSetting(const char *field, const char *newValue)
 #if defined(ESP8266)
   const uint32_t _noopCrcBefore = crc32(&settings, sizeof(settings));
 #else
+  // noqa: settings-snapshot — ESP32 has plentiful DRAM; the ESP8266
+  // core's crc32() helper is not part of the ESP32 Arduino API.
   static OTGWSettings _noopSnapshot;
   memcpy(&_noopSnapshot, &settings, sizeof(settings));
 #endif

--- a/src/OTGW-firmware/settingStuff.ino
+++ b/src/OTGW-firmware/settingStuff.ino
@@ -11,6 +11,9 @@
 */
 
 #include <ctype.h>
+#if defined(ESP8266)
+  #include <coredecls.h>   // ESP8266 SDK crc32(); used by updateSetting() no-op detection
+#endif
 
 //=======================================================================
 // Deferred settings write support (Finding #23: reduce flash wear + service restarts)
@@ -617,16 +620,16 @@ void updateSetting(const char *field, const char *newValue)
   // 6 full /settings.ini rewrites in 14 s for a single SAT/BLE form interaction
   // because identical-value writes (satblemac flushed twice with the same empty
   // value; satexternaltemp toggled false→true→false→true) all marked the
-  // settings dirty. Snapshot the entire OTGWSettings struct + pendingSideEffects
-  // before the dispatch cascade runs; if memcmp shows zero diff after, restore
-  // pendingSideEffects and return early without setting settingsDirty or
-  // restarting the debounce timer.
-  //
-  // Static buffer (one per call site, not on stack) — OTGWSettings is ~1-2 KB on
-  // ESP8266 and would otherwise pressure the stack. updateSetting() is not
-  // re-entered (REST handler is sequential), so static is safe.
+  // settings dirty. On ESP8266 the snapshot uses a CRC32 sentinel (~4 B local
+  // vs ~1.7 KB BSS for the previous full-struct memcmp); on ESP32 the full
+  // struct copy is retained because DRAM is plentiful and crc32() isn't part
+  // of the ESP32 core's public API.
+#if defined(ESP8266)
+  const uint32_t _noopCrcBefore = crc32(&settings, sizeof(settings));
+#else
   static OTGWSettings _noopSnapshot;
   memcpy(&_noopSnapshot, &settings, sizeof(settings));
+#endif
   const uint8_t pendingSideEffectsSnapshot = pendingSideEffects;
 
   if (strcasecmp_P(field, PSTR("hostname"))==0)
@@ -1114,7 +1117,11 @@ void updateSetting(const char *field, const char *newValue)
   // NOT restart the debounce timer (which would have triggered a wasted flash
   // rewrite). Verified by smoke test toggling satblemac twice with the same
   // empty value: only one would-be flush fires.
+#if defined(ESP8266)
+  if (crc32(&settings, sizeof(settings)) == _noopCrcBefore) {
+#else
   if (memcmp(&_noopSnapshot, &settings, sizeof(settings)) == 0) {
+#endif
     pendingSideEffects = pendingSideEffectsSnapshot;
     DebugTf(PSTR("[Settings] no-op skip: field[%s] equals current value, no flush scheduled\r\n"), field);
     return;


### PR DESCRIPTION
## Summary

Implements PR A from the memory audit (#644) — the **mechanical, low-risk trims** that reclaim ~3.4 KB of static DRAM on the ESP8266 build of 2.0.0. Brings the firmware from **91.3 % static DRAM (act-now zone) back into 87.2 %** (watch zone), restoring HEALTHY-tier free-heap operation per ADR-030/089. No SAT algorithm changes, no settings schema changes, no behaviour visible to MQTT / REST / Web clients.

## Measured impact (fresh PlatformIO ESP8266 build, `firmware.elf`)

| Section | Baseline (alpha.84) | After PR A | Δ |
|---|---:|---:|---:|
| `.text` (sketch) | 839,772 B | 840,908 B | +1,136 B (.rodata moved to flash) |
| `.data` | 27,664 B | 24,804 B | **−2,860 B** |
| `.bss` | 47,152 B | 46,640 B | **−512 B** |
| **Total static DRAM** | 74,816 B | **71,444 B** | **−3,372 B** |
| Static DRAM % of 81,920 | 91.3 % | **87.21 %** | **−4.1 pp** |
| Free for stack + heap | 7,108 B | **10,476 B** | +3,368 B |

After the trims, free-heap headroom is ~10 KB at boot — above ADR-030 / 089's HEALTHY tier (>8 KB) instead of permanently in WARN / CRITICAL.

## What this PR contains

| Commit | Trim | Saving | Risk |
|---|---|---:|---|
| `af7d5de` | **Trim 1** — `_noopSnapshot` → CRC32 sentinel on ESP8266 (ESP32 keeps memcmp under `#else`) | −1,736 B | Low — CRC32 collision prob 2⁻³² ≈ 270k years to first miss; collision is harmless (one missed no-op flash write) |
| `6042243` | **Trim 2** — `kSatMqttCmds` dispatch table → `PROGMEM` + `memcpy_P` row read | −996 B | Low — mechanical; same pattern as the existing PROGMEM helpers |
| `44237f5` | **Trim 6** — FSexplorer `sendIndex::lineBuf` → stack-local | −512 B | Low — also fixes a latent re-entrancy hazard via `feedWatchDog→yield` |
| `4dcd8d9` | **Bonus** — `kV2Routes` (REST dispatch) → `PROGMEM` (same pattern as Trim 2) | −128 B | Low |
| `57d2586` | **Regression guards** — `evaluate.py` checks for the two anti-patterns (`static OTGWSettings/State` outside canonical globals; non-PROGMEM k* dispatch tables) | — | `--quick` pipeline; honours inline `noqa` markers |

## Trim 4 — already done

The audit predicted ~354 B from gating the BLE roster (`sBleMAC`, `sBleMac[]`, `sBleLabel[]`) under `#if defined(ESP32)`. Verified during implementation that the codebase **already** has this gate at `SATtypes.h:461` and the corresponding writer at `settingStuff.ino:387`. No work to do; the audit doc has been over-counting this saving in the "remaining gap" calculation.

## What's deferred to PR B

- Trim 3 — `.rodata` PROGMEM sweep on the new SAT / discovery code paths (~2–3 KB)
- Trim 5 — `satPublishMQTT::climAttrBuf` 512 B → streaming publish

Those need careful per-callsite review and a focused field test of their own.

## Test plan

- [x] PlatformIO `pio run -e esp8266` succeeds (`python build.py --target esp8266 --firmware`)
- [x] `xtensa-lx106-elf-size -B firmware.elf` confirms `−3,372 B` total DRAM vs baseline
- [x] `python evaluate.py --quick` green (66 PASS, 0 FAIL, 0 WARN) including the two new regression-guard checks
- [ ] Maintainer review of the CRC32 sentinel logic in `settingStuff.ino:updateSetting()` — collision behaviour, ESP32 fallback under `#else`
- [ ] Field test as a tagged beta:
  - Save settings via Web UI; confirm no-op repeat-save is still skipped (telnet `s` shows no flash-write log line on the second click).
  - Trigger SAT MQTT subcommands and v2 REST routes; both dispatch tables must still resolve their handlers correctly.
  - Load `/index.html` from a browser; confirm `?v=<hash>` injection on `index.js` / `graph.js` references still works.
- [ ] `getFreeHeap()` from telnet `s` should report ~6 KB higher than alpha.84 on the same hardware.

## Refs

- Memory audit doc: `docs/memory-audit-1.6.1-beta-vs-2.0.0-alpha.84.md` (PR #644 on dev)
- ADRs: ADR-030 (heap tiers), ADR-077 (streaming HA discovery), ADR-078 (dispatch tables), ADR-079 (per-component types), ADR-089 (heap tier-machine), ADR-090 (re-entrancy guard for shared scratch)

https://claude.ai/code/session_01JtHaeA23RXr1KnmpQdDv8a

---
_Generated by [Claude Code](https://claude.ai/code/session_01JtHaeA23RXr1KnmpQdDv8a)_