### PR TITLE
docs(releases): fix broken internal links in 1.6.0-beta release notes

### DIFF
--- a/docs/releases/RELEASE_NOTES_1.6.0-beta.md
+++ b/docs/releases/RELEASE_NOTES_1.6.0-beta.md
@@ -44,7 +44,7 @@ The bullets below summarise the user-visible changes that have landed on `dev` s
 **Code hygiene**
 - **Dead and orphaned code paths cleaned out of `dev`**: inactive subsystem code and its matching scaffolding in `OTGW-firmware.h` removed, since neither is reachable on the 1.5.x / 1.6.x line.
 
-For per-commit detail see [`CHANGELOG.md`](CHANGELOG.md) under `## [Unreleased]`. For architectural rationale see the linked ADRs under [`docs/adr/`](docs/adr/).
+For per-commit detail see [`CHANGELOG.md`](../../CHANGELOG.md) under `## [Unreleased]`. For architectural rationale see the linked ADRs under [`docs/adr/`](../../docs/adr/).
 
 <!-- digest:end -->
 
@@ -122,7 +122,7 @@ Below is the long-form version of the digest above, with one section per area an
 
 ## Where to read more
 
-- [`CHANGELOG.md`](CHANGELOG.md): per-commit running log under `## [Unreleased]`.
+- [`CHANGELOG.md`](../../CHANGELOG.md): per-commit running log under `## [Unreleased]`.
 - [`README.md`](README.md): landing page, "What's new on dev" section.
-- [`docs/adr/`](docs/adr/): architectural rationale, in particular ADR-073 (JIT discovery), ADR-074 (HA availability), ADR-075 (proxy-answer routing).
-- [`docs/guides/`](docs/guides/): flash, build, MQTT, and integration guides.
+- [`docs/adr/`](../../docs/adr/): architectural rationale, in particular ADR-073 (JIT discovery), ADR-074 (HA availability), ADR-075 (proxy-answer routing).
+- [`docs/guides/`](../../docs/guides/): flash, build, MQTT, and integration guides.


### PR DESCRIPTION
## Fix broken internal links in 1.6.0-beta release notes

The `Run evaluate.py --quick` job's **markdown internal-link checker** is failing on `dev` (and therefore on every PR targeting `dev`). The release notes used file-relative links that resolve under `docs/releases/`, where the targets don't exist:

| Link | Resolved to | Fixed to |
|---|---|---|
| `CHANGELOG.md` | `docs/releases/CHANGELOG.md` ❌ | `../../CHANGELOG.md` |
| `docs/adr/` | `docs/releases/docs/adr` ❌ | `../../docs/adr/` |
| `docs/guides/` | `docs/releases/docs/guides` ❌ | `../../docs/guides/` |

`CHANGELOG.md` lives at the repo root and `docs/adr/` / `docs/guides/` are repo-root paths, so the `../../` prefix is correct from `docs/releases/`. The `README.md` link on line 126 is left untouched — `docs/releases/README.md` exists, so that one already resolves.

### Verification
Ran the exact link-checker logic from the CI step locally over its full scope (`README.md` + `docs/{releases,api,features,guides,process}`): **"Markdown internal link check PASSED."**

### Why a standalone PR
This is pre-existing doc debt unrelated to any feature work; surfaced while CI ran against an unrelated design-mockup PR (#649). Kept separate so the fix lands on its own.

https://claude.ai/code/session_01VeQt4e69s8iViYHtGsR3fn

---
_Generated by [Claude Code](https://claude.ai/code/session_01VeQt4e69s8iViYHtGsR3fn)_