### PR TITLE
docs(2.0.0): research note on full async modernization

### DIFF
--- a/docs/research/2.0.0-async-modernization.md
+++ b/docs/research/2.0.0-async-modernization.md
@@ -1,0 +1,209 @@
+# Onderzoek: volledig async voor OTGW-firmware 2.0.0
+
+> Status: **Onderzoek / advies** (geen besluit). Datum: 2026-06-03.
+> Scope: de 2.0.0 ESP32 / OTGW32-lijn. De 1.5/1.7 `dev`-lijn houdt het bestaande
+> coöperatieve model.
+> Doel: in kaart brengen wat "volledig async" betekent, wat het oplost, welke
+> componenten/bibliotheken bestaan, en wat de impact is. Dit document is invoer
+> voor een nog op te stellen ADR over het 2.0.0 concurrency-model.
+
+## TL;DR
+
+De huidige firmware draait op een **coöperatief single-core model** (ESP8266): één
+`loop()` die om de beurt elk subsysteem een klein, niet-blokkerend hapje werk laat
+doen, bewaakt door een hardware-watchdog. Dat model heeft over de jaren ~10 aparte
+ADR's nodig gehad om blokkades weg te masseren (ADR-047/048/058/080…). Dat is het
+echte symptoom: *elk* subsysteem dat ergens op wacht moet handmatig in
+niet-blokkerende stukjes gehakt worden.
+
+Voor 2.0.0 (ESP32 / OTGW32) liggen er **twee modernisatie-assen** open, los of samen
+te nemen:
+
+1. **Event-driven async networking** — vervang de pollende synchrone libs
+   (`ESP8266WebServer`, `PubSubClient`, `WebSocketsServer`) door de AsyncTCP-stack
+   (`ESPAsyncWebServer` + `espMqttClient` + `AsyncWebSocket`). Callback-gedreven,
+   geen `handleClient()` meer in de loop.
+2. **FreeRTOS task-based concurrency** — benut de twee cores + preemptive scheduler
+   van de ESP32: geef de veiligheidskritische PIC-seriële lijn een eigen task,
+   netwerk een eigen task, met queues ertussen.
+
+Belangrijkste strategische inzicht: **op de ESP32 lossen FreeRTOS-tasks veel van het
+blokkeerprobleem op zónder dat je per se naar event-driven async hoeft** — je mag
+synchrone, blokkerende code houden zolang die in een eigen task draait. "Volledig
+async" is dus geen enkele keuze maar een spectrum.
+
+---
+
+## 1. Huidige situatie (het 8266 coöperatieve model)
+
+De kern zit in `src/OTGW-firmware/OTGW-firmware.ino`: `doBackgroundTasks()` (rond
+regel 384) en `loop()` (rond regel 429):
+
+```cpp
+// doBackgroundTasks() — sequentieel, elke handler moet "snel klaar" zijn
+feedWatchDog();
+...
+debugTelnet.loop();
+OTGWstream.loop();
+handleMQTT();
+handleOTGW();
+handleWebSocket();
+httpServer.handleClient();   // pollende synchrone webserver
+MDNS.update();
+loopNTP();
+yield();
+```
+
+Eigenschappen van dit model, gecodificeerd in ADR's:
+
+| ADR | Wat het regelt | Waarom het bestaat |
+|---|---|---|
+| **ADR-001** | ESP8266-platformkeuze | uitgangspunt: single-core, ~40KB RAM |
+| **ADR-007** | `safeTimers.h` / `DUE()` polling-scheduler | geen threads; `loop()` mag nooit >paar ms blokkeren |
+| **ADR-010** | meerdere services op aparte poorten (80/81/23/25238 + MQTT) | allemaal binnen één loop bedienen |
+| **ADR-011** | externe hardware-watchdog, voeden ≤3s | hangt de loop, dan reset |
+| **ADR-047** | non-blocking WiFi-reconnect als handmatige state machine | `WiFi.reconnect()` blokkeerde |
+| **ADR-048** | non-blocking webhook als handmatige state machine | uitgaande HTTP-call blokkeerde |
+| **ADR-058** | PIC `PR=` queries via command-queue i.p.v. `executeCommand()` | 2s busy-wait → "web GUI traag, halve pagina's, timeouts" (v1.3.1-bug) |
+| **ADR-080** | MQTT `connect()` 15s sync-blocker *geaccepteerd* | PubSubClient connect is synchroon; tot ~36% loop-budget tijdens broker-outage |
+
+Plus de regels in `CLAUDE.md` over **"Static buffers, cooperative scheduling"** en
+re-entrancy via `feedWatchDog()` → `yield()`: gedeelde scratchbuffers zijn fragiel
+omdat de loop zichzelf opnieuw kan binnenkomen.
+
+**Rode draad:** elke feature die ergens op wacht (netwerk, seriële PIC, sensor) moet
+handmatig omgebouwd worden tot een toestandsmachine of queue-interactie. Dat is het
+terugkerende ontwerp- en bugoppervlak. Concrete restanten in de code:
+
+- `httpServer.handleClient()` poll elke loop (`OTGW-firmware.ino:420`).
+- `MQTTclient.connect()` synchroon, 15s timeout (`MQTTstuff.ino:827/832`, ADR-080).
+- `handleOTGW()` begrensd tot 4 regels/call om de loop niet te verhongeren
+  (TASK-671, `OTGW-Core.ino:4528`).
+- OneWire-sensoruitlezing in `pollSensors()` — bus-fysisch blokkerend, niet
+  firmware-tunbaar (ADR-080, Item 7).
+
+---
+
+## 2. Wat lost "volledig async" op
+
+1. **Veiligheidskritische PIC-lijn ontkoppelen.** Nu deelt de UART-drain het
+   loop-budget en moet hij kunstmatig begrensd worden (4 regels/call). Een eigen
+   FreeRTOS-task op core 1 garandeert dat de RX-FIFO altijd geleegd wordt, ongeacht
+   wat web of MQTT doet. Grootste betrouwbaarheidswinst.
+2. **Geen handmatige toestandsmachines meer.** ADR-047 (WiFi), ADR-048 (webhook),
+   ADR-058 (PIC PR=), ADR-080 (MQTT connect) bestaan puur omdat blokkeren verboden
+   is. In een async/task-model mág je blokkeren in je eigen context — die machines
+   versimpelen of verdwijnen.
+3. **Geen "spiral of death" / watchdog-koppeling** tussen ongerelateerde
+   subsystemen. Eén traag onderdeel verhongert de rest niet.
+4. **Responsievere web-UI** onder belasting: ESPAsyncWebServer bedient requests
+   vanaf de AsyncTCP-task, niet via polling tussen alle andere handlers door.
+5. **Eenvoudiger nieuwe features**: wachten op I/O wordt normaal i.p.v. een ADR
+   waard.
+
+---
+
+## 3. Componenten / bibliotheken (actuele staat, juni 2026)
+
+### Event-driven async stack
+- **AsyncTCP** (basis, ESP32) — onderhouden onder de **ESP32Async** org (de forks van
+  *mathieucarbou*; de originele `me-no-dev`-versie is feitelijk dood). Draait een
+  eigen FreeRTOS-task; callbacks lopen in die taskcontext.
+- **ESPAsyncWebServer** (ESP32Async-fork) — async HTTP + ingebouwde
+  **AsyncWebSocket** + SSE + auth. Vervangt zowel `ESP8266WebServer` (poort 80) als
+  de losse `WebSocketsServer` (poort 81) — consolidatie naar poort 80 mogelijk.
+- **espMqttClient** (bertmelis/emelis) — non-blocking, volledig MQTT 3.1.1-compliant,
+  geschreven door een (ex-)maintainer van AsyncMqttClient. **Aanbevolen boven
+  AsyncMqttClient**, die nauwelijks meer onderhouden wordt. De auteur merkt op dat je
+  op een dual-core ESP32 *strikt genomen geen async MQTT nodig hebt* — je kunt ook
+  blokkerend publiceren vanuit een eigen task.
+
+### Task-based concurrency (geen extra libs)
+- **FreeRTOS** zit al in de Arduino-ESP32 core (ESP-IDF eronder).
+  `xTaskCreatePinnedToCore`, queues (`xQueueCreate`), mutexes/semaphores. Geen externe
+  dependency.
+- ESP32 heeft een **Task Watchdog Timer (TWDT)** per core + interrupt-watchdog
+  ingebouwd → de externe hardware-watchdog (ADR-011) verandert van rol of vervalt.
+
+### Sterk referentieproject
+**EMS-ESP32** (firmware voor Bosch/Buderus-ketelgateways: ESP32, HA-discovery, MQTT,
+web-UI — architectonisch bijna een tweelingproject van OTGW) draait precies deze
+combinatie: **ESPAsyncWebServer + espMqttClient + FreeRTOS-tasks**, en migreerde
+expliciet van AsyncMqttClient → espMqttClient. Beste blauwdruk en risicobeperker.
+
+---
+
+## 4. Impact per subsysteem
+
+| Subsysteem | Nu | Async/task | Omvang |
+|---|---|---|---|
+| **Webserver** (`restAPI.ino` dispatch, `FSexplorer`, file-streaming, OTA-upload) | `ESP8266WebServer` + `handleClient()` polling | herschrijf naar request/response-callbacks; chunked response i.p.v. loop; OTA via `onUpload`-callback; file-serve via `request->send(LittleFS,…)` | **Groot** — grootste oppervlak |
+| **MQTT** | `PubSubClient`, 15s sync connect | `espMqttClient`; connect/LWT/discovery/retained/callbacks herschrijven; ADR-006/040/041/052/066/073 hervalideren | **Groot** |
+| **WebSocket** (OT-log) | `WebSocketsServer` poort 81 | `AsyncWebSocket` poort 80; ADR-005/025 (Safari) opnieuw testen | Middel |
+| **PIC seriële lijn** | begrensde drain in loop (4 regels/call) | **eigen FreeRTOS-task** core 1, hoge prio; queue naar de rest | Middel — **grootste winst** |
+| **Telnet debug (23) + ser2net (25238)** | `SimpleTelnet`/`WiFiServer` | blijven kan in eigen task, of AsyncTCP | Klein–middel |
+| **Handmatige state machines** | ADR-047/048/058 | versimpelen/intrekken | Klein (verwijderwerk) |
+| **Gedeelde state** | `OTGWState`/`OTGWSettings` (ADR-051) | **thread-safety**: door meerdere tasks benaderd → mutex of single-writer-discipline | **Subtiel & kritisch** |
+
+### De lastigste, minst zichtbare kost: thread-safety
+Zowel AsyncTCP-callbacks als FreeRTOS-tasks introduceren **echte gelijktijdigheid**.
+De `OTGWState`-struct wordt dan vanuit meerdere contexten gelezen/geschreven. Dat
+vraagt mutexes of een strikt single-writer/queue-ontwerp. Geen mechanische port maar
+een ontwerpbeslissing — en waar de meeste async-ESP32-bugs zitten.
+
+### Wat de ESP32-overstap meeneemt (los van async)
+- ~320KB+ RAM i.p.v. ~40KB → de `String`-verboden (ADR-004) en static-buffer-dwang
+  (ADR-053) **versoepelen**. Maar: AsyncTCP alloceert per-connectie buffers op de
+  heap, en callbacks hebben een **beperkte stack** (geen zware/blokkerende of
+  grote-stack-operaties; LittleFS-toegang vanuit een callback is risicovol).
+
+---
+
+## 5. Risico's & aandachtspunten
+
+- **Platform-scope eerst beslissen.** AsyncTCP is een ESP32-verhaal; `ESPAsyncTCP`
+  voor ESP8266 is wankel. De async-lijn is realistisch **ESP32-only** — past bij
+  2.0.0 (OTGW32). De 1.5/1.7 `dev`-lijn houdt het coöperatieve model.
+- **Dependency-risico**: de ESPAsyncWebServer-fork wordt "best effort" onderhouden.
+  ADR-080 noemde een lib-vervanging al expliciet "out of scope" wegens
+  hertest-kosten — dat hertesten wordt nu het hoofdwerk.
+- **Volledige HA-pipeline hertesten**: discovery, retained, LWT, availability
+  (ADR-041/052/062/066/073/074). Veldvalidatie via Discord `#beta-testing`
+  onmisbaar.
+- **ADR-corpus**: minstens ADR-007, 010, 011, 047, 048, 058, 080 moeten
+  *gesuperseded* worden door nieuwe 2.0.0-ADR's (in de 2.0.0-worktree, eigen
+  nummering). Per `CLAUDE.md` is dit een human-checkpoint-traject.
+
+---
+
+## 6. Aanbevolen aanpak (gefaseerd, laag → hoog risico)
+
+0. **ADR: concurrency-model 2.0.0** — kies expliciet tussen *event-driven async*
+   (AsyncTCP), *task-based* (FreeRTOS, synchrone code in tasks) óf een hybride. Dit
+   is dé beslissing; alles hangt eraan.
+1. **PIC-seriële task** — kleinste oppervlak, grootste betrouwbaarheidswinst,
+   onafhankelijk van het web. Goede eerste stap om het FreeRTOS-patroon (+ queue +
+   state-locking) te bewijzen.
+2. **MQTT → espMqttClient** — heft ADR-080's 15s-blocker op; goed afgebakend;
+   EMS-ESP32 als referentie.
+3. **Web + WebSocket → ESPAsyncWebServer/AsyncWebSocket** — grootste port, als
+   laatste als het patroon staat.
+4. **Handmatige state machines opruimen** (ADR-047/048/058) + watchdog-rol herzien
+   (ADR-011).
+
+> Inschatting: een **hybride** is het pragmatischst — FreeRTOS-task voor de PIC-lijn
+> (veiligheid) + event-driven async voor web/MQTT/WS (responsiviteit), met één
+> heldere state-locking-discipline. Precies wat het vergelijkbare EMS-ESP32 doet.
+
+---
+
+## Bronnen
+- ESP32Async / mathieucarbou — ESPAsyncWebServer: <https://github.com/mathieucarbou/ESPAsyncWebServer>
+- mathieucarbou — AsyncTCP: <https://github.com/mathieucarbou/AsyncTCP>
+- espMqttClient (emelis): <https://www.emelis.net/espMqttClient/>
+- EMS-ESP32 — migratie AsyncMqttClient → espMqttClient (#1178): <https://github.com/emsesp/EMS-ESP32/issues/1178>
+- marvinroger/AsyncMqttClient (minder onderhouden): <https://github.com/marvinroger/async-mqtt-client>
+
+## Gerelateerd
+- ADR-001, ADR-007, ADR-010, ADR-011, ADR-047, ADR-048, ADR-058, ADR-080
+- `CLAUDE.md` — "Static buffers, cooperative scheduling", "Timer management"


### PR DESCRIPTION
## Wat

Onderzoeksnotitie (`docs/research/2.0.0-async-modernization.md`) over het volledig async maken van de 2.0.0/ESP32-lijn, weg van het ESP8266 coöperatieve single-loop model.

Docs-only — geen firmware-wijziging, geen build/evaluator-impact.

## Inhoud

- **Huidige situatie**: coöperatief single-core model, met de ~10 ADR's (007/010/011/047/048/058/080) die bestaan om blokkades te omzeilen.
- **Twee modernisatie-assen**: (1) event-driven async networking via de AsyncTCP-stack, (2) FreeRTOS task-based concurrency. Plus het inzicht dat een hybride op de ESP32 het pragmatischst is.
- **Wat het oplost**: PIC-lijn ontkoppelen (veiligheid), handmatige state machines schrappen, geen watchdog-koppeling, responsievere UI.
- **Bibliotheken (juni 2026)**: ESP32Async/mathieucarbou `ESPAsyncWebServer` + `AsyncTCP`, `espMqttClient` (boven het minder-onderhouden AsyncMqttClient), FreeRTOS. Referentieproject: EMS-ESP32.
- **Impact per subsysteem** + de subtiele thread-safety-kost op `OTGWState`.
- **Gefaseerde aanpak** met ADR-besluit als stap 0.

## Vervolg

Invoer voor een nog op te stellen 2.0.0-ADR over het concurrency-model (event-driven vs task-based vs hybride). Geen besluit genomen in deze PR.

https://claude.ai/code/session_01Ndoo8RRorDynC6V5jM811f

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ndoo8RRorDynC6V5jM811f)_