### PR TITLE
docs(2.0.0): async modernization — research note + ADR-123 (Proposed)

### DIFF
--- a/docs/adr/ADR-123-2-0-0-concurrency-model-async-modernization.md
+++ b/docs/adr/ADR-123-2-0-0-concurrency-model-async-modernization.md
@@ -1,0 +1,245 @@
+# ADR-123: 2.0.0 Concurrency Model — Hybrid FreeRTOS PIC Task + Event-Driven Async Networking on ESP32, Cooperative Loop Retained on ESP8266
+
+## Status
+
+Proposed — drafted 2026-06-04, awaiting maintainer (Robert) approval. Do not treat
+as binding until accepted.
+
+## Context
+
+### Problem
+
+The 2.0.0 firmware still runs the ESP8266-era **cooperative single-loop** model:
+`loop()` → `doBackgroundTasks()` calls every subsystem in turn, each obliged to
+return within a few milliseconds, policed by an external hardware watchdog
+(ADR-011). Every subsystem that has to *wait* on I/O — WiFi, the PIC serial line,
+MQTT connect, an outbound webhook — has had to be hand-rewritten as a non-blocking
+state machine or queue interaction. That tax is visible across a string of ADRs:
+ADR-007 (timer scheduler), ADR-010 (concurrent services in one loop), ADR-047
+(non-blocking WiFi reconnect), ADR-048 (non-blocking webhook), ADR-058
+(non-blocking PIC `PR=`), ADR-108 (MQTT `connect()` accepted as a 15 s synchronous
+loop-blocker). The recurring cost is the design and bug surface: each new
+I/O-bound feature must be chopped into non-blocking fragments, and shared scratch
+buffers are fragile because the loop can re-enter itself via `feedWatchDog()` →
+`yield()`.
+
+The 2.0.0 / OTGW32 hardware moves to the **ESP32**, which brings two capabilities
+the ESP8266 lacked: a dual-core **FreeRTOS** preemptive scheduler, and ~320 KB+ RAM
+(vs ~40 KB). This is the natural moment to decide whether — and how — 2.0.0 sheds
+the cooperative model. The supporting research is in
+`docs/research/2.0.0-async-modernization.md`.
+
+### The decisive constraint: 2.0.0 is dual-target
+
+2.0.0 is **not** ESP32-only. It is a dual-target line that still builds and ships
+for the ESP8266 *and* the ESP32/OTGW32 (ADR-061 unified platform abstraction,
+ADR-072 SAT compatibility layer, ADR-082 ESP8266 Arduino-Core LTS pin, ADR-083
+PlatformIO dual-target; CI builds both `pio run -e esp8266` and `pio run -e esp32`).
+The event-driven async stack (`AsyncTCP`/`ESPAsyncWebServer`) is ESP32-centric;
+the ESP8266 equivalent (`ESPAsyncTCP`) is poorly maintained and historically
+crash-prone. "Fully async" therefore *cannot* be applied uniformly to both
+targets. Any decision here is really a decision about the **platform-abstraction
+boundary**, not about "2.0.0 vs dev".
+
+### Constraints
+
+- **Dual-target.** ESP8266 must keep building and behaving as today (ADR-082 pins
+  its toolchain). The async path is ESP32-only and must sit behind the platform
+  abstraction (ADR-061/072/120).
+- **The PIC UART is safety-critical and bursty.** OT frames arrive ~1 Hz but in
+  bursts; the RX FIFO must never overrun. Today `handleOTGW()` is bounded to four
+  lines per call (TASK-671) precisely so a noisy PIC cannot starve the loop.
+- **Dependency maturity.** The maintained `ESPAsyncWebServer`/`AsyncTCP` live under
+  the ESP32Async (mathieucarbou) fork on a "best effort" basis; the original
+  me-no-dev repos are effectively dead. `espMqttClient` (bertmelis) is the
+  actively maintained non-blocking MQTT client and supersedes `AsyncMqttClient`.
+- **HA contract surface.** Discovery, retained state, LWT, and availability are
+  governed by a large ADR set (ADR-041/052/077/088/096/097/102/104/108…). Any MQTT
+  client swap must re-validate all of it.
+- **No automated firmware tests.** Validation is build-green + `evaluate.py` +
+  field testing in Discord `#beta-testing`. Concurrency bugs are the hardest class
+  to catch this way, which raises the bar on the thread-safety design.
+
+## Decision
+
+Adopt a **platform-conditional hybrid concurrency model** for 2.0.0, selected at
+compile time behind the existing platform abstraction (ADR-061/072/120).
+
+### ESP32 / OTGW32 target
+
+1. **Dedicated FreeRTOS task for the PIC UART.** A single high-priority task,
+   pinned to the application core (core 1 / `APP_CPU`), is the *only* code that
+   touches `OTGWSerial`: it drains RX continuously and transmits from the command
+   queue. This removes the four-lines-per-call bound (TASK-671) and guarantees the
+   FIFO is serviced regardless of network load. This is the primary reliability
+   win and the first phase to land.
+2. **Event-driven async networking.** HTTP, WebSocket, and MQTT move to the
+   AsyncTCP stack: `ESPAsyncWebServer` (ESP32Async fork) with its built-in
+   `AsyncWebSocket` (consolidated onto port 80, retiring the separate
+   `WebSocketsServer` on 81), and `espMqttClient` for MQTT. These run on AsyncTCP's
+   own task (core 0 / `PRO_CPU`). This removes `httpServer.handleClient()` polling
+   from the loop and eliminates ADR-108's 15 s synchronous connect blocker.
+3. **Residual periodic work stays in `loop()`** on the Arduino task: timers
+   (ADR-007), sensor polling, NTP, JIT discovery drip. These are not I/O-blocked
+   and need no task of their own.
+4. **Thread-safety discipline.** Parsed OT frames cross from the PIC task to
+   consumers through a FreeRTOS queue. `OTGWState` follows a **single-writer-per-
+   field** rule; the small set of genuinely shared mutable fields is guarded by a
+   FreeRTOS mutex. No subsystem reads `OTGWSerial` or writes another subsystem's
+   state fields directly. This discipline is the load-bearing part of the decision
+   and the main source of risk.
+
+### ESP8266 target
+
+Retains the cooperative single-loop model unchanged (ADR-007/010/011/047/048/058).
+All FreeRTOS-task and AsyncTCP code is compiled out behind the platform
+abstraction. ESP8266 behaviour is intended to be byte-for-byte what it is today.
+
+### Rollout
+
+Phased, each phase its own backlog task, build/evaluator gates, field-validation,
+and ADR supersession where it lands:
+
+0. This ADR (the model decision).
+1. ESP32 PIC-UART FreeRTOS task + queue + state-locking discipline.
+2. MQTT → `espMqttClient` (ESP32 path); re-validate the HA pipeline; supersede
+   ADR-108 on the ESP32 side.
+3. Web + WebSocket → `ESPAsyncWebServer`/`AsyncWebSocket` (ESP32 path).
+4. Retire the now-redundant ESP32-side manual state machines (ADR-047/048/058
+   ESP32 variants) and re-scope the watchdog role (ADR-011) for the ESP32 TWDT.
+
+### Why this choice
+
+The hybrid puts preemption exactly where the cooperative model is weakest — the
+safety-critical PIC UART — while using event-driven async for the
+network-fan-out problem the AsyncTCP stack was built for. It keeps the dual-target
+promise (ADR-082) by confining all of it to the ESP32 side of the platform
+abstraction. It matches the proven shape of EMS-ESP32, an architecturally near-
+identical project (ESP32, HA discovery, MQTT, async web UI) that runs
+`ESPAsyncWebServer` + `espMqttClient` + FreeRTOS tasks.
+
+### Enforcement
+
+Manual review only at this stage. This is a forward-looking architectural decision
+with no single code surface yet; each rollout phase will add its own enforceable
+boundaries (e.g. "only the PIC task may reference `OTGWSerial`") in the ADR that
+lands that phase. No declarative `Enforcement` block until Phase 1.
+
+## Alternatives Considered
+
+### Alternative 1 — Port the cooperative loop as-is to ESP32
+Keep the single-loop model on both targets; treat the ESP32 as a faster ESP8266.
+
+**Pros:** zero architectural risk; one code path; no thread-safety work.
+**Cons:** wastes the ESP32's dual core; keeps the manual-state-machine tax and
+ADR-108's 15 s connect blocker; new I/O features keep costing an ADR each.
+**Rejected:** it spends the hardware upgrade on nothing and leaves the actual pain
+(blocking-avoidance) in place.
+
+### Alternative 2 — Full event-driven async, including an async PIC path, no dedicated task
+Drive everything (incl. the serial line) from AsyncTCP callbacks; no FreeRTOS task
+for the PIC.
+
+**Pros:** one concurrency mechanism; smallest task count.
+**Cons:** AsyncTCP callbacks run with a limited (~8 KB) stack and must not block —
+a poor fit for a bursty safety-critical UART; you would still hand-roll a serial
+state machine; LittleFS access from callbacks is fragile.
+**Rejected:** the PIC UART is exactly the surface that benefits from a dedicated
+preemptive task; forcing it into the async callback model recreates the problem we
+are trying to remove.
+
+### Alternative 3 — Task-per-subsystem keeping the existing synchronous libraries
+Run `ESP8266WebServer`/`PubSubClient` unchanged but each inside its own FreeRTOS
+task, blocking freely.
+
+**Pros:** familiar synchronous code; removes blocking from the loop without
+learning the async APIs; espMqttClient's author notes a dual-core ESP32 can simply
+publish synchronously from a task.
+**Cons:** keeps the polling web server (unmaintained on ESP32) and PubSubClient's
+synchronous connect; one stack per task inflates RAM despite the ESP32's headroom;
+forgoes the maintained ESPAsyncWebServer/espMqttClient ecosystem and its built-in
+WebSocket/SSE/auth.
+**Rejected as the primary model**, but it is the natural *fallback* if the
+AsyncTCP fork's maintenance risk (see Consequences) materialises — the task-based
+shape is reusable.
+
+### Alternative 4 — ESP32-only async; drop ESP8266 from 2.0.0
+Make 2.0.0 async everywhere by dropping the ESP8266 target.
+
+**Pros:** one (async) code path; no platform divergence; simplest async story.
+**Cons:** breaks ADR-082's explicit LTS-pin commitment to keep ESP8266 building on
+2.0.0, and contradicts the ADR-061/072 dual-target design.
+**Rejected:** not the maintainer's stated direction; would strand existing ESP8266
+hardware on the 1.x line.
+
+### Alternative 5 — ESP-IDF-native rewrite (drop Arduino)
+Rebuild on ESP-IDF to get first-class FreeRTOS/event-loop primitives.
+
+**Pros:** native concurrency and networking primitives; no third-party async fork.
+**Cons:** contradicts ADR-013 (Arduino framework over ESP-IDF); rewrites the entire
+codebase and every vendored library; enormous surface for a hobby-scale
+maintenance team.
+**Rejected:** scope is disproportionate; ADR-013 stands.
+
+## Consequences
+
+### Positive
+- **PIC reliability:** a dedicated preemptive task guarantees UART drain
+  independent of network load; the four-lines-per-call bound (TASK-671) can be
+  removed.
+- **Loop simplification:** `httpServer.handleClient()` polling and the ESP32-side
+  manual state machines (ADR-047/048/058) disappear; new I/O-bound features no
+  longer each need a bespoke non-blocking rewrite.
+- **Responsiveness:** the web UI and MQTT are serviced from their own tasks, not
+  between every other handler; ADR-108's 15 s connect stall is gone on ESP32.
+- **Maintained dependencies:** ESP32Async + espMqttClient are actively maintained
+  and battle-tested in EMS-ESP32.
+- **Headroom:** ESP32 RAM relaxes the strict static-buffer/`String`-prohibition
+  posture on the ESP32 path (ADR-004/042 remain in force on ESP8266).
+
+### Negative
+- **Two concurrency models to maintain** behind the platform abstraction — the
+  ESP32 async/task path and the ESP8266 cooperative path — for as long as 2.0.0
+  ships ESP8266. This is the real, recurring cost of keeping ADR-082.
+- **Thread-safety is now a first-class concern.** `OTGWState` is touched from the
+  PIC task, the AsyncTCP task, and the loop. Getting the single-writer/mutex
+  discipline wrong yields exactly the hard-to-field-debug races this project's
+  test model is weakest against.
+- **Async callback constraints** (limited stack, no blocking, careful LittleFS
+  use) are new footguns for contributors.
+- **Large re-validation surface:** the entire HA discovery/retained/LWT/
+  availability pipeline must be re-tested against `espMqttClient`.
+- **ADR churn:** several 2.0.0 ADRs (007/010/011/047/048/058/108) need ESP32-side
+  superseding as phases land.
+
+### Risks & Mitigation
+- **Risk:** the ESP32Async fork is "best effort" and could stall.
+  **Mitigation:** Alternative 3 (task-based, synchronous libs) is a pre-identified
+  fallback that reuses the same FreeRTOS task structure.
+- **Risk:** state races under concurrency.
+  **Mitigation:** single-writer-per-field rule + mutex on shared fields, codified
+  and enforced per-phase; queue-based hand-off for OT frames; land Phase 1 (PIC
+  task) first in isolation to prove the pattern before networking changes.
+- **Risk:** ESP8266 regressions from platform-abstraction churn.
+  **Mitigation:** ESP8266 path compiled unchanged; CI keeps `pio run -e esp8266`
+  green as the guard.
+
+## Related Decisions
+
+- **Builds on / constrained by:** ADR-061 (unified ESP8266/ESP32 abstraction),
+  ADR-072 (SAT platform compatibility layer), ADR-082 (ESP8266 Core LTS pin),
+  ADR-083 (PlatformIO dual-target build), ADR-120 (platform abstraction headers),
+  ADR-013 (Arduino over ESP-IDF).
+- **Expected to supersede (ESP32 side, per phase):** ADR-047, ADR-048, ADR-058,
+  ADR-108; re-scopes ADR-007, ADR-010, ADR-011.
+- **Re-validation touch-points:** ADR-005/025 (WebSocket), ADR-006/041/052/077/088/
+  096/097/102/104 (MQTT + HA discovery), ADR-121 (per-consumer heap gating).
+- **Research input:** `docs/research/2.0.0-async-modernization.md`.
+
+## References
+
+- ESP32Async / mathieucarbou — ESPAsyncWebServer: <https://github.com/mathieucarbou/ESPAsyncWebServer>
+- mathieucarbou — AsyncTCP: <https://github.com/mathieucarbou/AsyncTCP>
+- espMqttClient (bertmelis): <https://www.emelis.net/espMqttClient/>
+- EMS-ESP32 — AsyncMqttClient → espMqttClient migration (#1178): <https://github.com/emsesp/EMS-ESP32/issues/1178>
+- ESP-IDF FreeRTOS SMP / `xTaskCreatePinnedToCore`: <https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-reference/system/freertos.html>

--- a/docs/adr/ADR-123-2-0-0-concurrency-model-async-modernization.md
+++ b/docs/adr/ADR-123-2-0-0-concurrency-model-async-modernization.md
@@ -2,8 +2,11 @@
 
 ## Status
 
-Proposed — drafted 2026-06-04, awaiting maintainer (Robert) approval. Do not treat
-as binding until accepted.
+Proposed — drafted 2026-06-04. Direction confirmed by the maintainer (Robert) on
+2026-06-04: the **hybrid model is adopted**, and the long-term ESP8266 dual-target
+disposition is **deferred** (revisit after Phase 1). Awaiting explicit acceptance
+of this amended text before the status flips to Accepted; do not treat as binding
+until then.
 
 ## Context
 
@@ -89,11 +92,21 @@ compile time behind the existing platform abstraction (ADR-061/072/120).
    state fields directly. This discipline is the load-bearing part of the decision
    and the main source of risk.
 
-### ESP8266 target
+### ESP8266 target — unchanged during rollout; long-term fate deferred
 
-Retains the cooperative single-loop model unchanged (ADR-007/010/011/047/048/058).
-All FreeRTOS-task and AsyncTCP code is compiled out behind the platform
-abstraction. ESP8266 behaviour is intended to be byte-for-byte what it is today.
+For the duration of the rollout the ESP8266 target retains the cooperative
+single-loop model unchanged (ADR-007/010/011/047/048/058); all FreeRTOS-task and
+AsyncTCP code is compiled out behind the platform abstraction, so ESP8266 behaviour
+stays byte-for-byte what it is today. The FreeRTOS PIC task and the AsyncTCP stack
+are inherently ESP32-only (the ESP8266 has no preemptive multicore scheduler), so
+the ESP32 work does not touch the ESP8266 path.
+
+**Deferred sub-decision (open).** Whether ESP8266 remains a first-class 2.0.0
+target indefinitely — permanent platform-divergent concurrency, honouring ADR-082's
+LTS pin — or is eventually phased out so 2.0.0 converges on a single async path is
+**not decided here** (maintainer choice, 2026-06-04). Phase 1 (the ESP32 PIC task)
+does not depend on that answer, so the call is deferred to a follow-up ADR taken
+after Phase 1 lands. Until then, ESP8266 is retained as-is.
 
 ### Rollout
 
@@ -169,8 +182,9 @@ Make 2.0.0 async everywhere by dropping the ESP8266 target.
 **Pros:** one (async) code path; no platform divergence; simplest async story.
 **Cons:** breaks ADR-082's explicit LTS-pin commitment to keep ESP8266 building on
 2.0.0, and contradicts the ADR-061/072 dual-target design.
-**Rejected:** not the maintainer's stated direction; would strand existing ESP8266
-hardware on the 1.x line.
+**Deferred, not rejected:** the maintainer chose (2026-06-04) to leave the ESP8266
+disposition open. This stays a live option to revisit via a follow-up ADR after
+Phase 1; it is not foreclosed, but it is not adopted now.
 
 ### Alternative 5 — ESP-IDF-native rewrite (drop Arduino)
 Rebuild on ESP-IDF to get first-class FreeRTOS/event-loop primitives.
@@ -200,7 +214,9 @@ maintenance team.
 ### Negative
 - **Two concurrency models to maintain** behind the platform abstraction — the
   ESP32 async/task path and the ESP8266 cooperative path — for as long as 2.0.0
-  ships ESP8266. This is the real, recurring cost of keeping ADR-082.
+  ships ESP8266. Whether that burden is permanent (keep ESP8266) or temporary
+  (eventually drop it) is the deferred sub-decision above; this ADR commits only to
+  carrying both during the rollout.
 - **Thread-safety is now a first-class concern.** `OTGWState` is touched from the
   PIC task, the AsyncTCP task, and the loop. Getting the single-writer/mutex
   discipline wrong yields exactly the hard-to-field-debug races this project's

--- a/docs/research/2.0.0-async-modernization.md
+++ b/docs/research/2.0.0-async-modernization.md
@@ -1,0 +1,209 @@
+# Onderzoek: volledig async voor OTGW-firmware 2.0.0
+
+> Status: **Onderzoek / advies** (geen besluit). Datum: 2026-06-03.
+> Scope: de 2.0.0 ESP32 / OTGW32-lijn. De 1.5/1.7 `dev`-lijn houdt het bestaande
+> coöperatieve model.
+> Doel: in kaart brengen wat "volledig async" betekent, wat het oplost, welke
+> componenten/bibliotheken bestaan, en wat de impact is. Dit document is invoer
+> voor een nog op te stellen ADR over het 2.0.0 concurrency-model.
+
+## TL;DR
+
+De huidige firmware draait op een **coöperatief single-core model** (ESP8266): één
+`loop()` die om de beurt elk subsysteem een klein, niet-blokkerend hapje werk laat
+doen, bewaakt door een hardware-watchdog. Dat model heeft over de jaren ~10 aparte
+ADR's nodig gehad om blokkades weg te masseren (ADR-047/048/058/080…). Dat is het
+echte symptoom: *elk* subsysteem dat ergens op wacht moet handmatig in
+niet-blokkerende stukjes gehakt worden.
+
+Voor 2.0.0 (ESP32 / OTGW32) liggen er **twee modernisatie-assen** open, los of samen
+te nemen:
+
+1. **Event-driven async networking** — vervang de pollende synchrone libs
+   (`ESP8266WebServer`, `PubSubClient`, `WebSocketsServer`) door de AsyncTCP-stack
+   (`ESPAsyncWebServer` + `espMqttClient` + `AsyncWebSocket`). Callback-gedreven,
+   geen `handleClient()` meer in de loop.
+2. **FreeRTOS task-based concurrency** — benut de twee cores + preemptive scheduler
+   van de ESP32: geef de veiligheidskritische PIC-seriële lijn een eigen task,
+   netwerk een eigen task, met queues ertussen.
+
+Belangrijkste strategische inzicht: **op de ESP32 lossen FreeRTOS-tasks veel van het
+blokkeerprobleem op zónder dat je per se naar event-driven async hoeft** — je mag
+synchrone, blokkerende code houden zolang die in een eigen task draait. "Volledig
+async" is dus geen enkele keuze maar een spectrum.
+
+---
+
+## 1. Huidige situatie (het 8266 coöperatieve model)
+
+De kern zit in `src/OTGW-firmware/OTGW-firmware.ino`: `doBackgroundTasks()` (rond
+regel 384) en `loop()` (rond regel 429):
+
+```cpp
+// doBackgroundTasks() — sequentieel, elke handler moet "snel klaar" zijn
+feedWatchDog();
+...
+debugTelnet.loop();
+OTGWstream.loop();
+handleMQTT();
+handleOTGW();
+handleWebSocket();
+httpServer.handleClient();   // pollende synchrone webserver
+MDNS.update();
+loopNTP();
+yield();
+```
+
+Eigenschappen van dit model, gecodificeerd in ADR's:
+
+| ADR | Wat het regelt | Waarom het bestaat |
+|---|---|---|
+| **ADR-001** | ESP8266-platformkeuze | uitgangspunt: single-core, ~40KB RAM |
+| **ADR-007** | `safeTimers.h` / `DUE()` polling-scheduler | geen threads; `loop()` mag nooit >paar ms blokkeren |
+| **ADR-010** | meerdere services op aparte poorten (80/81/23/25238 + MQTT) | allemaal binnen één loop bedienen |
+| **ADR-011** | externe hardware-watchdog, voeden ≤3s | hangt de loop, dan reset |
+| **ADR-047** | non-blocking WiFi-reconnect als handmatige state machine | `WiFi.reconnect()` blokkeerde |
+| **ADR-048** | non-blocking webhook als handmatige state machine | uitgaande HTTP-call blokkeerde |
+| **ADR-058** | PIC `PR=` queries via command-queue i.p.v. `executeCommand()` | 2s busy-wait → "web GUI traag, halve pagina's, timeouts" (v1.3.1-bug) |
+| **ADR-080** | MQTT `connect()` 15s sync-blocker *geaccepteerd* | PubSubClient connect is synchroon; tot ~36% loop-budget tijdens broker-outage |
+
+Plus de regels in `CLAUDE.md` over **"Static buffers, cooperative scheduling"** en
+re-entrancy via `feedWatchDog()` → `yield()`: gedeelde scratchbuffers zijn fragiel
+omdat de loop zichzelf opnieuw kan binnenkomen.
+
+**Rode draad:** elke feature die ergens op wacht (netwerk, seriële PIC, sensor) moet
+handmatig omgebouwd worden tot een toestandsmachine of queue-interactie. Dat is het
+terugkerende ontwerp- en bugoppervlak. Concrete restanten in de code:
+
+- `httpServer.handleClient()` poll elke loop (`OTGW-firmware.ino:420`).
+- `MQTTclient.connect()` synchroon, 15s timeout (`MQTTstuff.ino:827/832`, ADR-080).
+- `handleOTGW()` begrensd tot 4 regels/call om de loop niet te verhongeren
+  (TASK-671, `OTGW-Core.ino:4528`).
+- OneWire-sensoruitlezing in `pollSensors()` — bus-fysisch blokkerend, niet
+  firmware-tunbaar (ADR-080, Item 7).
+
+---
+
+## 2. Wat lost "volledig async" op
+
+1. **Veiligheidskritische PIC-lijn ontkoppelen.** Nu deelt de UART-drain het
+   loop-budget en moet hij kunstmatig begrensd worden (4 regels/call). Een eigen
+   FreeRTOS-task op core 1 garandeert dat de RX-FIFO altijd geleegd wordt, ongeacht
+   wat web of MQTT doet. Grootste betrouwbaarheidswinst.
+2. **Geen handmatige toestandsmachines meer.** ADR-047 (WiFi), ADR-048 (webhook),
+   ADR-058 (PIC PR=), ADR-080 (MQTT connect) bestaan puur omdat blokkeren verboden
+   is. In een async/task-model mág je blokkeren in je eigen context — die machines
+   versimpelen of verdwijnen.
+3. **Geen "spiral of death" / watchdog-koppeling** tussen ongerelateerde
+   subsystemen. Eén traag onderdeel verhongert de rest niet.
+4. **Responsievere web-UI** onder belasting: ESPAsyncWebServer bedient requests
+   vanaf de AsyncTCP-task, niet via polling tussen alle andere handlers door.
+5. **Eenvoudiger nieuwe features**: wachten op I/O wordt normaal i.p.v. een ADR
+   waard.
+
+---
+
+## 3. Componenten / bibliotheken (actuele staat, juni 2026)
+
+### Event-driven async stack
+- **AsyncTCP** (basis, ESP32) — onderhouden onder de **ESP32Async** org (de forks van
+  *mathieucarbou*; de originele `me-no-dev`-versie is feitelijk dood). Draait een
+  eigen FreeRTOS-task; callbacks lopen in die taskcontext.
+- **ESPAsyncWebServer** (ESP32Async-fork) — async HTTP + ingebouwde
+  **AsyncWebSocket** + SSE + auth. Vervangt zowel `ESP8266WebServer` (poort 80) als
+  de losse `WebSocketsServer` (poort 81) — consolidatie naar poort 80 mogelijk.
+- **espMqttClient** (bertmelis/emelis) — non-blocking, volledig MQTT 3.1.1-compliant,
+  geschreven door een (ex-)maintainer van AsyncMqttClient. **Aanbevolen boven
+  AsyncMqttClient**, die nauwelijks meer onderhouden wordt. De auteur merkt op dat je
+  op een dual-core ESP32 *strikt genomen geen async MQTT nodig hebt* — je kunt ook
+  blokkerend publiceren vanuit een eigen task.
+
+### Task-based concurrency (geen extra libs)
+- **FreeRTOS** zit al in de Arduino-ESP32 core (ESP-IDF eronder).
+  `xTaskCreatePinnedToCore`, queues (`xQueueCreate`), mutexes/semaphores. Geen externe
+  dependency.
+- ESP32 heeft een **Task Watchdog Timer (TWDT)** per core + interrupt-watchdog
+  ingebouwd → de externe hardware-watchdog (ADR-011) verandert van rol of vervalt.
+
+### Sterk referentieproject
+**EMS-ESP32** (firmware voor Bosch/Buderus-ketelgateways: ESP32, HA-discovery, MQTT,
+web-UI — architectonisch bijna een tweelingproject van OTGW) draait precies deze
+combinatie: **ESPAsyncWebServer + espMqttClient + FreeRTOS-tasks**, en migreerde
+expliciet van AsyncMqttClient → espMqttClient. Beste blauwdruk en risicobeperker.
+
+---
+
+## 4. Impact per subsysteem
+
+| Subsysteem | Nu | Async/task | Omvang |
+|---|---|---|---|
+| **Webserver** (`restAPI.ino` dispatch, `FSexplorer`, file-streaming, OTA-upload) | `ESP8266WebServer` + `handleClient()` polling | herschrijf naar request/response-callbacks; chunked response i.p.v. loop; OTA via `onUpload`-callback; file-serve via `request->send(LittleFS,…)` | **Groot** — grootste oppervlak |
+| **MQTT** | `PubSubClient`, 15s sync connect | `espMqttClient`; connect/LWT/discovery/retained/callbacks herschrijven; ADR-006/040/041/052/066/073 hervalideren | **Groot** |
+| **WebSocket** (OT-log) | `WebSocketsServer` poort 81 | `AsyncWebSocket` poort 80; ADR-005/025 (Safari) opnieuw testen | Middel |
+| **PIC seriële lijn** | begrensde drain in loop (4 regels/call) | **eigen FreeRTOS-task** core 1, hoge prio; queue naar de rest | Middel — **grootste winst** |
+| **Telnet debug (23) + ser2net (25238)** | `SimpleTelnet`/`WiFiServer` | blijven kan in eigen task, of AsyncTCP | Klein–middel |
+| **Handmatige state machines** | ADR-047/048/058 | versimpelen/intrekken | Klein (verwijderwerk) |
+| **Gedeelde state** | `OTGWState`/`OTGWSettings` (ADR-051) | **thread-safety**: door meerdere tasks benaderd → mutex of single-writer-discipline | **Subtiel & kritisch** |
+
+### De lastigste, minst zichtbare kost: thread-safety
+Zowel AsyncTCP-callbacks als FreeRTOS-tasks introduceren **echte gelijktijdigheid**.
+De `OTGWState`-struct wordt dan vanuit meerdere contexten gelezen/geschreven. Dat
+vraagt mutexes of een strikt single-writer/queue-ontwerp. Geen mechanische port maar
+een ontwerpbeslissing — en waar de meeste async-ESP32-bugs zitten.
+
+### Wat de ESP32-overstap meeneemt (los van async)
+- ~320KB+ RAM i.p.v. ~40KB → de `String`-verboden (ADR-004) en static-buffer-dwang
+  (ADR-053) **versoepelen**. Maar: AsyncTCP alloceert per-connectie buffers op de
+  heap, en callbacks hebben een **beperkte stack** (geen zware/blokkerende of
+  grote-stack-operaties; LittleFS-toegang vanuit een callback is risicovol).
+
+---
+
+## 5. Risico's & aandachtspunten
+
+- **Platform-scope eerst beslissen.** AsyncTCP is een ESP32-verhaal; `ESPAsyncTCP`
+  voor ESP8266 is wankel. De async-lijn is realistisch **ESP32-only** — past bij
+  2.0.0 (OTGW32). De 1.5/1.7 `dev`-lijn houdt het coöperatieve model.
+- **Dependency-risico**: de ESPAsyncWebServer-fork wordt "best effort" onderhouden.
+  ADR-080 noemde een lib-vervanging al expliciet "out of scope" wegens
+  hertest-kosten — dat hertesten wordt nu het hoofdwerk.
+- **Volledige HA-pipeline hertesten**: discovery, retained, LWT, availability
+  (ADR-041/052/062/066/073/074). Veldvalidatie via Discord `#beta-testing`
+  onmisbaar.
+- **ADR-corpus**: minstens ADR-007, 010, 011, 047, 048, 058, 080 moeten
+  *gesuperseded* worden door nieuwe 2.0.0-ADR's (in de 2.0.0-worktree, eigen
+  nummering). Per `CLAUDE.md` is dit een human-checkpoint-traject.
+
+---
+
+## 6. Aanbevolen aanpak (gefaseerd, laag → hoog risico)
+
+0. **ADR: concurrency-model 2.0.0** — kies expliciet tussen *event-driven async*
+   (AsyncTCP), *task-based* (FreeRTOS, synchrone code in tasks) óf een hybride. Dit
+   is dé beslissing; alles hangt eraan.
+1. **PIC-seriële task** — kleinste oppervlak, grootste betrouwbaarheidswinst,
+   onafhankelijk van het web. Goede eerste stap om het FreeRTOS-patroon (+ queue +
+   state-locking) te bewijzen.
+2. **MQTT → espMqttClient** — heft ADR-080's 15s-blocker op; goed afgebakend;
+   EMS-ESP32 als referentie.
+3. **Web + WebSocket → ESPAsyncWebServer/AsyncWebSocket** — grootste port, als
+   laatste als het patroon staat.
+4. **Handmatige state machines opruimen** (ADR-047/048/058) + watchdog-rol herzien
+   (ADR-011).
+
+> Inschatting: een **hybride** is het pragmatischst — FreeRTOS-task voor de PIC-lijn
+> (veiligheid) + event-driven async voor web/MQTT/WS (responsiviteit), met één
+> heldere state-locking-discipline. Precies wat het vergelijkbare EMS-ESP32 doet.
+
+---
+
+## Bronnen
+- ESP32Async / mathieucarbou — ESPAsyncWebServer: <https://github.com/mathieucarbou/ESPAsyncWebServer>
+- mathieucarbou — AsyncTCP: <https://github.com/mathieucarbou/AsyncTCP>
+- espMqttClient (emelis): <https://www.emelis.net/espMqttClient/>
+- EMS-ESP32 — migratie AsyncMqttClient → espMqttClient (#1178): <https://github.com/emsesp/EMS-ESP32/issues/1178>
+- marvinroger/AsyncMqttClient (minder onderhouden): <https://github.com/marvinroger/async-mqtt-client>
+
+## Gerelateerd
+- ADR-001, ADR-007, ADR-010, ADR-011, ADR-047, ADR-048, ADR-058, ADR-080
+- `CLAUDE.md` — "Static buffers, cooperative scheduling", "Timer management"

--- a/docs/research/2.0.0-async-modernization.md
+++ b/docs/research/2.0.0-async-modernization.md
@@ -1,8 +1,11 @@
 # Onderzoek: volledig async voor OTGW-firmware 2.0.0
 
 > Status: **Onderzoek / advies** (geen besluit). Datum: 2026-06-03.
-> Scope: de 2.0.0 ESP32 / OTGW32-lijn. De 1.5/1.7 `dev`-lijn houdt het bestaande
-> coöperatieve model.
+> Scope: de 2.0.0-lijn. **Let op:** 2.0.0 is een *dual-target* lijn — zowel
+> ESP8266 als ESP32/OTGW32 (ADR-061/072/082/083; CI bouwt `pio run -e esp8266`
+> én `-e esp32`). De async-stack is ESP32-centrisch, dus de modernisatie raakt
+> hier de platform-abstractie, niet "2.0.0 vs dev". De 1.5/1.7 `dev`-lijn houdt
+> het bestaande coöperatieve model.
 > Doel: in kaart brengen wat "volledig async" betekent, wat het oplost, welke
 > componenten/bibliotheken bestaan, en wat de impact is. Dit document is invoer
 > voor een nog op te stellen ADR over het 2.0.0 concurrency-model.
@@ -161,9 +164,14 @@ een ontwerpbeslissing — en waar de meeste async-ESP32-bugs zitten.
 
 ## 5. Risico's & aandachtspunten
 
-- **Platform-scope eerst beslissen.** AsyncTCP is een ESP32-verhaal; `ESPAsyncTCP`
-  voor ESP8266 is wankel. De async-lijn is realistisch **ESP32-only** — past bij
-  2.0.0 (OTGW32). De 1.5/1.7 `dev`-lijn houdt het coöperatieve model.
+- **Dual-target is de scherpste constraint.** 2.0.0 ondersteunt ESP8266 *én*
+  ESP32/OTGW32 (ADR-061/072/082/083). AsyncTCP is een ESP32-verhaal; `ESPAsyncTCP`
+  voor ESP8266 is wankel. "Volledig async" kan op de ESP8266-target dus niet op
+  dezelfde manier. Realistische uitkomsten: (a) **platform-divergente
+  concurrency** — ESP32 async/FreeRTOS, ESP8266 houdt de coöperatieve loop, achter
+  de platform-abstractie (ADR-061/072/120); dat verdubbelt het onderhoudsoppervlak;
+  of (b) de ESP8266-target uit 2.0.0 fasen (botst met ADR-082's LTS-pin-belofte).
+  Deze keuze moet vóór alles vastliggen.
 - **Dependency-risico**: de ESPAsyncWebServer-fork wordt "best effort" onderhouden.
   ADR-080 noemde een lib-vervanging al expliciet "out of scope" wegens
   hertest-kosten — dat hertesten wordt nu het hoofdwerk.


### PR DESCRIPTION
## Wat

Groundwork voor het async-moderniseren van de 2.0.0-lijn, op de juiste feature branch:

1. **`docs/research/2.0.0-async-modernization.md`** — onderzoeksnotitie: huidige coöperatieve model, de twee modernisatie-assen (event-driven AsyncTCP-stack vs FreeRTOS task-based), wat het oplost, libraries (ESP32Async/ESPAsyncWebServer + AsyncTCP, espMqttClient, FreeRTOS), impact per subsysteem, thread-safety-risico, gefaseerde aanpak.
2. **`docs/adr/ADR-123-...`** — **Proposed** ADR die het concurrency-model voor 2.0.0 vastlegt.

Docs-only.

## Kernpunt: 2.0.0 is dual-target

2.0.0 bouwt zowel ESP8266 als ESP32/OTGW32 (ADR-061/072/082/083; CI: `pio run -e esp8266` én `-e esp32`). De async-stack is ESP32-centrisch, dus "volledig async" kan niet uniform. ADR-123 stelt daarom een **platform-conditioneel hybride** model voor:

- **ESP32:** dedicated FreeRTOS-task voor de PIC-UART + event-driven async voor web/WS/MQTT (`ESPAsyncWebServer`/`AsyncWebSocket`, `espMqttClient`); `OTGWState` met single-writer + mutex-discipline.
- **ESP8266:** coöperatieve loop blijft, achter de platform-abstractie (ADR-082-belofte).
- Gefaseerde uitrol (PIC-task → MQTT → web/WS → manuele state machines opruimen).

## Status

ADR-123 staat op **Proposed** — wacht op maintainer-goedkeuring (geen self-approve). Reviewpunten en trade-offs staan in de ADR (Alternatives 1–5, Consequences, Risks).

> Eerdere plaatsing op `dev` (PR #653) wordt teruggedraaid via PR #655.

https://claude.ai/code/session_01Ndoo8RRorDynC6V5jM811f