### PR TITLE
docs(adr): accept ADR-140 (single-device, five source prefixes) + ADR-141 (ArduinoJson v7)

### DIFF
--- a/docs/adr/ADR-042-streaming-json-no-arduinojson.md
+++ b/docs/adr/ADR-042-streaming-json-no-arduinojson.md
@@ -1,6 +1,6 @@
 # ADR-042: Streaming JSON I/O — No ArduinoJson
 
-**Status:** Accepted
+**Status:** Superseded by [ADR-141](ADR-141-adopt-arduinojson-v7-esp32s3.md) (2026-06-15) — the 2.0.0 ESP32-S3-only line (ADR-128 dropped ESP8266) re-adopts ArduinoJson v7; the no-ArduinoJson ban no longer applies there. This status line is the sanctioned immutability exception (body below unedited). Originally **Accepted** 2026-02-28.
 **Date:** 2026-02-28
 **Decision Maker:** User: Rob van den Breemen (rvdbreemen)
 **Supersedes:** ADR-018 (ArduinoJson for Data Interchange)

--- a/docs/adr/ADR-124-ha-discovery-seven-device-topology.md
+++ b/docs/adr/ADR-124-ha-discovery-seven-device-topology.md
@@ -1,11 +1,11 @@
 ---
 id: ADR-124
 title: HA Discovery Seven-Device Topology — Dedicated OT-Core and Sensors Devices, Gateway via_device Hub
-status: Accepted
+status: Superseded
 date: 2026-06-05
 tags: [mqtt, ha-discovery, topology, via-device, pic, otdirect, sensors, dallas, s0, esp, gateway]
 supersedes: [ADR-122]
-superseded_by: []
+superseded_by: [ADR-140]
 related: [ADR-122, ADR-077, ADR-070, ADR-106, ADR-088, ADR-080]
 deciders: [Robert van den Breemen]
 ---
@@ -13,6 +13,8 @@ deciders: [Robert van den Breemen]
 # ADR-124: HA Discovery Seven-Device Topology — Dedicated OT-Core and Sensors Devices, Gateway via_device Hub
 
 ## Status
+
+**Superseded by [ADR-140](ADR-140-single-device-ha-topology-entity-category-clustering.md) (2026-06-15)** — 2.0.0 returns to a single-device HA topology with source-prefix entity clustering; the seven-device split and `via_device` hub are removed. This status line is the sanctioned immutability exception (ADR body below is unedited).
 
 Accepted. Date: 2026-06-06 (Proposed 2026-06-05). **Supersedes ADR-122** (five-device topology).
 

--- a/docs/adr/ADR-140-single-device-ha-topology-entity-category-clustering.md
+++ b/docs/adr/ADR-140-single-device-ha-topology-entity-category-clustering.md
@@ -1,14 +1,23 @@
-# ADR-140: Single-Device HA Discovery Topology with Seven Categories in One Device (align 2.0.0 with the 1.6.x single-device model)
+# ADR-140: Single-Device HA Discovery Topology with Source-Prefix Entity Clustering in One Device (align 2.0.0 with the 1.6.x single-device model)
 
 ## Status
 
-Proposed, 2026-06-15. Guideline-level (per ADR-080): the discovery payload shape
-is verified by field validation (a captured discovery dump on a real device), not
-by a clean `evaluate.py` forbid/require pattern. **Supersedes ADR-124** (Seven-Device
+Accepted, 2026-06-15 (Proposed 2026-06-15; accepted by the maintainer 2026-06-15).
+Guideline-level (per ADR-080): the discovery payload shape is verified by field
+validation (a captured discovery dump on a real device), not by a clean
+`evaluate.py` forbid/require pattern. **Supersedes ADR-124** (Seven-Device
 Topology) and, transitively, the multi-device line ADR-124 sits on (ADR-122
-five-device). On acceptance, a "Superseded by ADR-140" status line is added to
-ADR-124 (the sanctioned immutability exception); ADR-124's body is not edited.
-While this ADR is Proposed those back-references are NOT applied.
+five-device). On acceptance (applied now), a "Superseded by ADR-140" status line
+is added to ADR-124 (the sanctioned immutability exception); ADR-124's body is not
+edited.
+
+**Acceptance note (2026-06-15):** acceptance incorporates the maintainer's naming
+directive — the in-device clustering is **five source/engine prefixes**
+(`esp_`, `pic_`, `otd_`, `sat_`, `sensors_`), NOT the seven functional categories
+(no `boiler_` / `thermostat_` / `gateway_` prefixes). §2 below is the accepted
+clustering scheme; the original Proposed draft's "seven categories" wording is
+superseded by it within this same ADR (the revision was applied while Proposed,
+before the flip to Accepted).
 
 ## Status History
 
@@ -17,6 +26,11 @@ status_history:
     status: Proposed
     changed_by: Agent
     reason: After field testing, revert the 2.0.0 multi-device HA topology (ADR-124 seven-device split with via_device hub) back to ONE device per hardware OTGW with entity_category clustering, matching the 1.6.x/dev model. The multi-device layout is confusing in practice; the seven-device path is also the source of the F1 two-pass determinism bug (ADR-077 Risks materialized). Hard-remove the seven-device code; single-device becomes the only model.
+    changed_via: manual
+  - date: 2026-06-15
+    status: Accepted
+    changed_by: maintainer (Robert van den Breemen)
+    reason: Accepted with the maintainer naming directive folded into §2 — in-device clustering uses five source/engine prefixes (esp_/pic_/otd_/sat_/sensors_), not the seven functional categories. Boiler/thermostat disambiguation moves to the 1.x bilateral _boiler/_thermostat suffix; gateway/OT-core fold onto the active engine prefix (pic_ or otd_). Supersedes ADR-124.
     changed_via: manual
 
 ## Context
@@ -81,23 +95,46 @@ Concrete shape:
    `identifiers`. No `via_device`, no multi-device split, no per-device suffix or
    metadata.
 
-2. **Clustering = seven categories inside the one device.** The seven former device
-   groupings (Boiler, Thermostat, Gateway, ESP, OT-Core, SAT, Sensors) survive as seven
-   CATEGORIES within the single device, not as seven devices. The existing
-   `deviceForOTId` classification (which already assigns every entity to one of the seven)
-   is repurposed from device-selection to category-selection, and the category is
-   rendered as an entity-name prefix (e.g. "Boiler Control Setpoint", "Thermostat Room
-   Setpoint", "ESP Free Heap"), so HA visibly groups the entities by category in the
-   device entity list and in any dashboard filter.
+2. **Clustering = five source/engine prefixes inside the one device (maintainer
+   directive 2026-06-15).** Every entity is prefixed by the SOURCE/ENGINE that produced
+   it, drawn from exactly five values — and the functional-role labels `boiler_`,
+   `thermostat_`, `gateway_` are **NOT** used as prefixes:
+
+   | Prefix | Source / engine |
+   |---|---|
+   | `esp_` | ESP32 firmware + diagnostics (heap, wifi, uptime, version, …) |
+   | `pic_` | OpenTherm values mediated by the OTGW Classic **PIC** firmware |
+   | `otd_` | OpenTherm values produced by the **OTDirect** engine (OTGW32) |
+   | `sat_` | Smart Autotune Thermostat subsystem, **including its BLE sensors** |
+   | `sensors_` | on-board hardware sensors (Dallas DS18B20, S0 pulse counter) |
+
+   The prefix is the engine/source, not the OpenTherm direction. Exactly one OT command
+   interface is active per build — `pic_` on the esp32-classic PIC build, `otd_` on the
+   esp32/OTGW32 OTDirect build, resolved at boot on esp32-combo — so every OT value
+   carries `pic_` or `otd_` accordingly. The former Boiler / Thermostat / Gateway /
+   OT-Core groupings all collapse onto the single source prefix of the active engine.
+   `deviceForOTId` and the `HaDevice` enum are RETAINED but repurposed to select this
+   source prefix instead of a device.
+
+   **Boiler vs thermostat disambiguation** (the bilateral case — one OT value reported by
+   both the thermostat side and the boiler side) is preserved by the existing 1.x
+   bilateral **suffix** `_boiler` / `_thermostat` on the entity id, NOT by a prefix. Both
+   readings stay distinct under the same source prefix without reintroducing a role prefix.
+
+   **Sensor recognizability (maintainer directive):** Dallas probes are `sensors_`-prefixed
+   with the probe address (or its configured label) in the entity name and a stable
+   per-address `unique_id`, so each physical probe is individually identifiable and
+   re-discovery does not duplicate. BLE sensors are `sat_`-prefixed and keep a `BLE` token
+   in the entity name (e.g. `sat_ble_temp` → "SAT BLE Temp").
 
    **HA constraint (why a name prefix, not native sections):** Home Assistant has only
    THREE native within-device sections (primary / Configuration / Diagnostic, via
-   `entity_category`). Seven native collapsible sections are not possible. The seven
-   categories are therefore a naming-prefix grouping (and optionally an HA label per
-   category for dashboard filtering). `entity_category` (`config` for writable settings,
+   `entity_category`). More native collapsible sections are not possible. The five source
+   prefixes are therefore a naming-prefix grouping (and optionally an HA label per source
+   for dashboard filtering). `entity_category` (`config` for writable settings,
    `diagnostic` for fault/counter/connectivity/PIC-settings readbacks) remains an
    ORTHOGONAL secondary layer that drops those entities into HA's native Config/Diagnostic
-   sections where it adds value, independent of the seven-category prefix.
+   sections where it adds value, independent of the source prefix.
 
 3. **Typing.** `device_class` + `unit_of_measurement` + `state_class` are set per entity
    for icon/unit/precision/statistics. Names are self-describing `friendlyName`
@@ -117,10 +154,11 @@ Concrete shape:
    seven-DEVICE output is deleted: the seven separate `dev` blocks, `via_device`, the
    per-device suffix/metadata tables, and the `deviceIntroduced[]` per-device array all
    go. The `HaDevice` seven-value enum and the `deviceForOTId` map are RETAINED but
-   repurposed to drive the category name-prefix (point 2) instead of device selection.
-   The bilateral Boiler/Thermostat handling is kept (a single OT value reported by both
-   sides still yields a Boiler-category and a Thermostat-category entity), now setting
-   the category prefix rather than a second device. Single-device is the only topology;
+   repurposed to drive the source name-prefix (point 2) instead of device selection.
+   The bilateral boiler/thermostat handling is kept (a single OT value reported by both
+   sides still yields two distinct entities), now disambiguated by the `_boiler` /
+   `_thermostat` SUFFIX under the same source prefix rather than by a second device or a
+   role prefix. Single-device is the only topology;
    the former `bLegacyMode` topology axis is retired (it was never persisted or parsed).
    The orthogonal topic-naming axis `bUseLegacyOtTopics` (ADR-106) is untouched.
 
@@ -153,8 +191,8 @@ driver-set first-entity gate.
 
 **Benefits**
 - Adopts the proven 1.6.x single-device topology (one device per hardware OTGW, easy to
-  read), while preserving the seven former groupings as in-device categories so no
-  classification information is lost.
+  read), while preserving entity grouping via five source/engine prefixes
+  (`esp_`/`pic_`/`otd_`/`sat_`/`sensors_`) so no source information is lost.
 - Removes finding F1 by construction (driver-set first-entity gate, no compose mutation).
 - Net code reduction: the `HaDevice` split, `deviceForOTId`, bilateral two-pass,
   `via_device`, per-device metadata, and `deviceIntroduced[]` all go.

--- a/docs/adr/ADR-141-adopt-arduinojson-v7-esp32s3.md
+++ b/docs/adr/ADR-141-adopt-arduinojson-v7-esp32s3.md
@@ -1,0 +1,140 @@
+---
+id: ADR-141
+title: Adopt ArduinoJson v7 for JSON on the ESP32-S3 2.0.0 line
+status: Accepted
+date: 2026-06-15
+tags: [json, arduinojson, mqtt, ha-discovery, rest, esp32s3, memory]
+supersedes: [ADR-042]
+superseded_by: []
+related: [ADR-042, ADR-018, ADR-128, ADR-140, ADR-089, ADR-077, ADR-131]
+deciders: [Robert van den Breemen]
+---
+
+# ADR-141: Adopt ArduinoJson v7 for JSON on the ESP32-S3 2.0.0 line
+
+## Status
+
+Accepted, 2026-06-15 (Proposed 2026-06-15; accepted by the maintainer 2026-06-15).
+**Supersedes ADR-042** (Streaming JSON I/O — No ArduinoJson). ADR-042 stays immutable;
+a "Superseded by ADR-141" status line is added to it (the sanctioned immutability
+exception), its body unedited.
+
+Guideline-level (per ADR-080) until the mechanical gate flips: ADR-042's ban is
+enforced today by `evaluate.py::check_no_arduinojson`. The Definition of Done of the
+implementing task (TASK-867) **removes/relaxes that gate** so ArduinoJson is permitted
+on the ESP32-S3 line; until then this ADR is a decision of record, not yet CI-enforced.
+
+## Status History
+
+status_history:
+  - date: 2026-06-15
+    status: Accepted
+    changed_by: maintainer (Robert van den Breemen)
+    reason: Reverse the no-ArduinoJson stance for the ESP32-S3-only 2.0.0 line. ADR-128 dropped ESP8266 (the RAM/fragmentation premise of ADR-042); the ESP32-S3 has 300 KB+ heap. The hand-rolled two-pass MqttJsonWriter is the source of review findings F1 (MEASURE/WRITE desync) and F5 (manual string-escaping gap). Both ESP32 reference projects (OT-Thing, EMS-ESP32) use ArduinoJson v7. Adopt it, starting with the MQTT HA-discovery path.
+    changed_via: manual
+
+## Context
+
+ADR-018 adopted ArduinoJson 6.x; ADR-042 (2026-02-28) then **banned** it in favour of a
+hand-rolled streaming/`snprintf_P` approach, because on the ESP8266 (~40 KB usable heap)
+the elastic document caused RAM pressure and heap fragmentation. That premise has since
+changed:
+
+1. **ESP8266 is gone.** ADR-128 dropped ESP8266 support from 2.0.0; the line is
+   ESP32-S3-only, with 300 KB+ heap and (on some boards) PSRAM. The RAM/fragmentation
+   argument that motivated ADR-042 no longer holds on the target hardware.
+2. **The hand-rolled path has cost.** The MQTT HA-discovery builder uses a two-pass
+   `MqttJsonWriter` (MEASURE then WRITE) because PubSubClient/`beginPublish` needed the
+   length up front. The 2.0.0 MQTT review found this two-pass is the root of **F1** (the
+   `deviceIntroduced[]` MEASURE-pass mutation desync that drops the device block / first
+   entity) and that the manual writer never escaped device strings (**F5**).
+3. **Both ESP32 reference projects use ArduinoJson v7.** OT-Thing-OTGW32 and EMS-ESP32
+   (the mature ESP32 blueprint) build discovery/state JSON with ArduinoJson v7 and a
+   `measureJson` + reserve/serialize publish pattern.
+4. **espMqttClient frames atomically** (ADR-131): a publish is a single
+   buffer-it-then-send call, which fits ArduinoJson's `measureJson` → allocate →
+   `serializeJson` → publish → free pattern cleanly.
+
+## Decision
+
+**Adopt ArduinoJson v7 for firmware JSON building on the ESP32-S3 2.0.0 line**, replacing
+the hand-rolled streaming/two-pass approach. ADR-042 is superseded for this line.
+
+1. **Dependency.** Add `bblanchon/ArduinoJson @ ^7` (latest 7.x) to the ESP32 envs in
+   `platformio.ini`.
+2. **Build pattern (atomic publish on espMqttClient).** Build a `JsonDocument`, then
+   `size_t n = measureJson(doc)`, allocate exactly `n` (or a reserved buffer),
+   `serializeJson(doc, buf, n)`, publish via the `mqttPublishRaw` chokepoint, free.
+   **Gate the allocation behind the ADR-089 heap tier** (refuse/defer under heap pressure,
+   matching the EMS-ESP32 pattern).
+3. **Scope and order.** MQTT HA-discovery building first (highest value — F1/F5 live
+   there), then the MQTT state/source publishes, then REST JSON building/parsing
+   (`parseJsonKVLine` inbound can move to `deserializeJson`). This ADR records the
+   direction; the discovery rewrite lands with ADR-140 (single-device) under TASK-867.
+4. **Removal.** Delete the `MqttJsonWriter` two-pass scaffold and its
+   `writeRam`/`writeProgmem`/`writeJsonKV` helpers. **F1** disappears (no hand-rolled
+   two-pass) and **F5** disappears (ArduinoJson escapes string values automatically).
+5. **Gate.** Remove/relax `evaluate.py::check_no_arduinojson` as part of TASK-867's
+   Definition of Done, so the ban no longer fails the ESP32-S3 build.
+
+## Alternatives Considered
+
+### Alternative A: Keep the hand-rolled two-pass writer (status quo, ADR-042)
+Rejected. It keeps the F1 determinism bug and the F5 escaping gap, and the two-pass
+length-measure complexity, for a RAM constraint that no longer exists on ESP32-S3.
+
+### Alternative B: Fix F1/F5 inside the two-pass writer, keep the ban
+Viable and in fact done for the single-device rewrite (ADR-140 fixes F1 by a driver-set
+first-entity gate and F5 by manual escaping). But it preserves the hand-rolled
+complexity long-term; the maintainer chose to converge on the library both reference
+projects use rather than maintain a bespoke writer.
+
+### Alternative C: Adopt ArduinoJson v7 (chosen)
+Matches the reference projects, removes F1/F5 by construction, and is affordable on the
+ESP32-S3 heap.
+
+## Consequences
+
+**Benefits**
+- Removes F1 and F5 by construction (no hand-rolled two-pass; automatic escaping).
+- Aligns with the OT-Thing and EMS-ESP32 reference implementations.
+- Simpler discovery/state/REST JSON code; deletes the `MqttJsonWriter` scaffold.
+
+**Trade-offs**
+- ArduinoJson v7 keeps an elastic heap-resident document while building. Affordable on
+  ESP32-S3 (300 KB+), bounded by the per-config worst case (~900 B) and freed immediately
+  after publish; still gated by the ADR-089 heap tier. PSRAM, where present, can back the
+  allocator later (EMS-ESP32 `AllocatorPSRAM`).
+- Flash cost of the library (watch the esp32-combo build headroom).
+- ADR-042's ban is reversed for this line only; the decision is recorded as a supersession,
+  not an edit to ADR-042.
+
+**Risks and mitigations**
+- *Risk*: entity-set regression during the discovery rewrite. *Mitigation*: the golden
+  test `tests/webui/ha-discovery-golden.test.mjs` asserts entity-set parity before/after.
+- *Risk*: heap spike on a full discovery republish. *Mitigation*: the ADR-089 tier defers
+  under pressure; `measureJson`-sized allocation is freed immediately after publish.
+
+## Related Decisions
+
+- **ADR-042 (No ArduinoJson)**: **superseded by this ADR** for the ESP32-S3 line.
+- **ADR-018 (ArduinoJson for Data Interchange)**: the original adoption ADR-042 reversed;
+  this ADR returns to a (newer, v7) ArduinoJson.
+- **ADR-128 (Drop ESP8266 from 2.0.0)**: the premise change that makes this affordable.
+- **ADR-140 (Single-Device HA Topology)**: the discovery rewrite that consumes ArduinoJson
+  (one `JsonDocument` per entity with a shared device block).
+- **ADR-089 (Heap tier machine)**: the gate the allocate/serialize path sits behind.
+- **ADR-131 (espMqttClient async engine)**: the atomic-publish model ArduinoJson serializes into.
+- **ADR-077 (Streaming MQTT HA Discovery)**: the two-pass MEASURE/WRITE contract this removes.
+- **ADR-080 (Binding ADR rules must have a CI gate)**: this ADR is guideline-level until
+  the `evaluate.py` ban is replaced (TASK-867 DoD).
+
+## References
+
+- Review findings folded in: F1 (`MQTTHaDiscovery.cpp` MEASURE-pass `deviceIntroduced[]`
+  mutation), F5 (unescaped hostname/manufacturer/model in the device block).
+- Reference pattern: EMS-ESP32 `src/core/mqtt.cpp` (ArduinoJson v7 + `measureJson`/reserve
+  + heap-gate); OT-Thing-OTGW32 `Firmware/src/mqtt.cpp` (ArduinoJson v7 discovery).
+- Change surface: `platformio.ini` (lib_deps), `src/OTGW-firmware/MQTTHaDiscovery.cpp`,
+  `src/OTGW-firmware/MQTTstuff.{ino,h}` (`MqttJsonWriter` deletion), `evaluate.py`
+  (`check_no_arduinojson` removal). Implementation tracked under TASK-867.


### PR DESCRIPTION
Maintainer accepted both ADRs (2026-06-15). Docs-only — no firmware change, no build/version gate.

## ADR-140 — Single-Device HA topology, **Accepted**
- Flipped Proposed → Accepted.
- **Folded in the five-prefix naming directive** (the part that was previously a maintainer instruction overriding the draft): in-device clustering is **`esp_` / `pic_` / `otd_` / `sat_` / `sensors_`**, and **not** `boiler_` / `thermostat_` / `gateway_` prefixes. The revision was applied while still Proposed, before the Accepted flip, since the ADR is immutable afterward.
- Mapping recorded in §2: OT values take the active-engine prefix (`pic_` on the Classic PIC build, `otd_` on OTGW32/OTDirect, resolved at boot on combo); the old Boiler/Thermostat/Gateway/OT-Core groupings collapse onto that. **Boiler/thermostat disambiguation** is preserved via the 1.x bilateral **suffix** `_boiler`/`_thermostat` (not a prefix).
- **Dallas → `sensors_`** (per-probe address + stable `unique_id`); **BLE → `sat_`** (keeps a `BLE` name token) — your "easily recognized" directive.
- **Supersedes ADR-124** (seven-device): ADR-124 marked `Superseded` (frontmatter + status line; body unedited — sanctioned immutability exception).

## ADR-141 — Adopt ArduinoJson v7, **Accepted** (newly authored)
ADR-141 did not exist; authored per the plan and accepted. Adopt `bblanchon/ArduinoJson @ ^7` on the ESP32-S3 line; **supersedes ADR-042** (no-ArduinoJson ban). Premise change: ADR-128 dropped ESP8266, so ADR-042's RAM/fragmentation rationale no longer applies; removes review findings F1/F5 by construction; matches OT-Thing/EMS-ESP32. ADR-042 marked `Superseded` (status line; body unedited).

## Verification
- `evaluate.py` **"ADR References Resolve"** check green (new ADR-141 link + the two superseded-by links resolve).

## What this unblocks (impl, separate PRs)
- **Phase 2 — TASK-871/872**: single-device discovery rewrite + the five-prefix naming + Dallas/BLE recognition (now that ADR-140 is Accepted). Updates `tests/webui/ha-discovery-golden.test.mjs` from seven-device → single-device.
- **Phase 4 — TASK-867**: the ArduinoJson v7 migration + removal of `evaluate.py::check_no_arduinojson`.

Draft pending your review of the §2 wording (especially the engine-prefix mapping and the bilateral-suffix decision) before it's relied on by the Phase 2 implementation.

https://claude.ai/code/session_01Hq82VEivxNsrLcUe5nxYYi

---
_Generated by [Claude Code](https://claude.ai/code/session_01Hq82VEivxNsrLcUe5nxYYi)_