### PR TITLE
docs(mqtt): fix stale HA-discovery comments (CCONOFF case, sensor count) — 1.x parity

### DIFF
--- a/src/OTGW-firmware/mqtt_configuratie.cpp
+++ b/src/OTGW-firmware/mqtt_configuratie.cpp
@@ -647,7 +647,7 @@ const char ha_name_solar_storage_slave_fault_indicator[] PROGMEM = "solar_storag
 const char ha_name_solar_storage_system_type[] PROGMEM = "solar_storage_system_type";
 const char ha_name_gateway_mode[] PROGMEM = "Gateway_Mode";
 const char ha_name_otgw_connected[] PROGMEM = "OTGW_Connected";
-// ========== Sensor array (289 entries, sorted by id) ==========
+// ========== Sensor array (335 entries) ==========
 const uint16_t MQTT_HA_SENSOR_COUNT = 335;  // +5 (uptime, unsupported_msgids, ws/mqtt/http_fragskips)
 
 const MqttHaSensorCfg PROGMEM mqttHaSensors[] = {
@@ -1189,7 +1189,8 @@ const MqttHaBinSensorCfg PROGMEM mqttHaBinSensors[] = {
     {113, 0x00, ha_lbl_solar_storage_system_type, ha_name_solar_storage_system_type, HaIcon::checkbox_marked_circle, HaEntityCat::none, true},
     // --- Pseudo-ID 244: gateway/OTGW connection status ---
     // Both use IS_PIC (0x08) -> otgw-pic/{gateway_mode,otgw_connected}. Values
-    // publish "on"/"off" via CCONOFF (default on_off payload).
+    // publish "ON"/"OFF" via CCONOFF; the on_off payload writes no pl_on/pl_off,
+    // so HA's default ON/OFF payloads apply and match.
     {244, 0x08, ha_lbl_gateway_mode,   ha_name_gateway_mode,   HaIcon::lan_connect, HaEntityCat::diagnostic, true},
     {244, 0x08, ha_lbl_otgw_connected, ha_name_otgw_connected, HaIcon::lan_connect, HaEntityCat::diagnostic, true},
 };


### PR DESCRIPTION
## Summary

Comment-only cleanup in `mqtt_configuratie.cpp`, bringing the 1.x line to parity with the two stale-comment fixes made on 2.0.0 (PR #668, from Copilot's review). **No behaviour change.**

- **id-244 binary rows:** `CCONOFF` publishes `"ON"/"OFF"` (uppercase), not `"on"/"off"`. Clarified that the `on_off` payload writes no `pl_on`/`pl_off`, so HA's default `ON`/`OFF` payloads apply and match — the code was already correct (mirrors `boiler_connected`); only the comment was misleading.
- **Sensor array header:** said "289 entries" but `MQTT_HA_SENSOR_COUNT` is 335 (the iteration bound). Corrected to 335.

## Context

Follow-up to the merged PR #669 (which added uptime/unsupported_msgids/fragskip sensors + `gateway_mode`/`otgw_connected` binary sensors to 1.x). Those same comments were flagged by Copilot on the 2.0.0 sibling (#668) and fixed there; this applies the identical wording fixes to `otgw-1.x.x` for consistency.

Comment-only, so no prerelease bump (per policy: comments are stripped by the compiler, no A/B-testable behaviour change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01YS6SBBJjnDCKuvmsJaZK5r)_